### PR TITLE
Add: support GA4 api

### DIFF
--- a/biothings/web/analytics/events.py
+++ b/biothings/web/analytics/events.py
@@ -1,14 +1,15 @@
 import hashlib
+
 # import smtplib
 import uuid
 from collections import UserDict
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from ipaddress import IPv4Address, IPv6Address, ip_address
+from pprint import pformat
 from random import randint
 from typing import Union
 from urllib.parse import urlencode
-from pprint import pformat
 
 
 class Event(UserDict):
@@ -30,12 +31,12 @@ class Event(UserDict):
         if self.user_agent:
             hash_val = 0
             for ordinal in map(ord, self.user_agent[::-1]):
-                hash_val = ((hash_val << 6) & 0xfffffff) + ordinal + (ordinal << 14)
-                left_most_7 = hash_val & 0xfe00000
+                hash_val = ((hash_val << 6) & 0xFFFFFFF) + ordinal + (ordinal << 14)
+                left_most_7 = hash_val & 0xFE00000
                 if left_most_7 != 0:
                     hash_val ^= left_most_7 >> 21
 
-        return ((randint(0, 0x7fffffff) ^ hash_val) & 0x7fffffff)
+        return (randint(0, 0x7FFFFFFF) ^ hash_val) & 0x7FFFFFFF
 
     def _cid_v2(self):
         # Author: Zhongchao Qian
@@ -58,7 +59,7 @@ class Event(UserDict):
             rip: Union[IPv4Address, IPv6Address] = ip_address(self.user_ip)
             ip_packed = rip.packed
         except ValueError:  # in the weird case I don't get an IP
-            ip_packed = randint(0, 0xffffffff).to_bytes(4, 'big')  # nosec
+            ip_packed = randint(0, 0xFFFFFFFF).to_bytes(4, 'big')  # nosec
 
         h = hashlib.blake2b(digest_size=16, salt=b'biothings')
         h.update(ip_packed)
@@ -66,8 +67,8 @@ class Event(UserDict):
 
         d = bytearray(h.digest())
         # truncating hash is not that bad, fixing some bits should be okay, too
-        d[6] = 0x40 | (d[6] & 0x0f)  # set version
-        d[8] = 0x80 | (d[8] & 0x3f)  # set variant
+        d[6] = 0x40 | (d[6] & 0x0F)  # set version
+        d[8] = 0x80 | (d[8] & 0x3F)  # set variant
         u = str(uuid.UUID(bytes=bytes(d)))
         return u
 
@@ -96,7 +97,7 @@ class Event(UserDict):
             "cid": self._cid(cid_version),
             "uip": self.user_ip,
             "dh": self.host,
-            "dp": self.path
+            "dp": self.path,
         }
 
         # add document referer
@@ -114,13 +115,15 @@ class Event(UserDict):
     def to_GA4_payload(self, measurement_id, cid_version=1):
         payload = {
             "name": "page_view",
-            "params": _clean({
-                "client_id": self._cid(cid_version),
-                "user_ip": self.user_ip,
-                "page_location": f'{self.host}{self.path}',
-                "page_title": self.path.strip('/').replace('/', '-') if self.path.strip('/') else 'index',
-                "page_path": self.path
-            })
+            "params": _clean(
+                {
+                    "client_id": self._cid(cid_version),
+                    "user_ip": self.user_ip,
+                    "page_location": f'{self.host}{self.path}',
+                    "page_title": self.path.strip('/').replace('/', '-'),
+                    "page_path": self.path,
+                }
+            ),
         }
 
         # add document referer
@@ -157,16 +160,22 @@ class GAEvent(Event):
 
         payloads = super().to_GA_payload(tracking_id, cid_version)
         if self.get("category") and self.get("action"):
-            payloads.append(urlencode(_clean({
-                "v": 1,  # protocol version
-                "t": "event",
-                "tid": tracking_id,
-                "cid": self._cid(cid_version),
-                "ec": self["category"],
-                "ea": self["action"],
-                "el": self.get("label", ""),
-                "ev": self.get("value", "")
-            })))
+            payloads.append(
+                urlencode(
+                    _clean(
+                        {
+                            "v": 1,  # protocol version
+                            "t": "event",
+                            "tid": tracking_id,
+                            "cid": self._cid(cid_version),
+                            "ec": self["category"],
+                            "ea": self["action"],
+                            "el": self.get("label", ""),
+                            "ev": self.get("value", ""),
+                        }
+                    )
+                )
+            )
         for event in self.get("__secondary__", []):
             event["__request__"] = self["__request__"]
             payloads.extend(event.to_GA_payload(tracking_id, cid_version)[1:])
@@ -178,15 +187,19 @@ class GAEvent(Event):
 
         payloads = super().to_GA4_payload(measurement_id, cid_version)
         if self.get("category") and self.get("action"):
-            payloads.append({
-                "name": self["action"],  # Event hit type
-                "params": _clean({
-                    "client_id": str(self._cid(cid_version)),  # Anonymous Client ID.
-                    "event_category": self["category"],  # Event Category. Required.
-                    "event_label": self.get("label", ""),  # Event label.
-                    "value": self.get("value", ""),  # Event value.
-                })
-            })
+            payloads.append(
+                {
+                    "name": self["action"],  # Event hit type
+                    "params": _clean(
+                        {
+                            "client_id": str(self._cid(cid_version)),  # Anonymous Client ID.
+                            "event_category": self["category"],  # Event Category. Required.
+                            "event_label": self.get("label", ""),  # Event label.
+                            "value": self.get("value", ""),  # Event value.
+                        }
+                    ),
+                }
+            )
         for event in self.get("__secondary__", []):
             event["__request__"] = self["__request__"]
             payloads.extend(event.to_GA4_payload(measurement_id, cid_version)[1:])
@@ -201,10 +214,11 @@ class Message(Event):
     Processable fields: title, body, url, url_text, image, image_altext
     Optionally define default field values below.
     """
+
     DEFAULTS = {
         "title": "Notification Message",
         "url_text": "View Details",
-        "image_altext": "<IMAGE>"
+        "image_altext": "<IMAGE>",
     }
 
     def __getattr__(self, attr):
@@ -222,24 +236,24 @@ class Message(Event):
         Generate ADF for Atlassian Jira payload. Overwrite this to build differently.
         https://developer.atlassian.com/cloud/jira/platform/apis/document/playground/
         """
-        adf = {
-            "version": 1,
-            "type": "doc",
-            "content": []
-        }
+        adf = {"version": 1, "type": "doc", "content": []}
         if self.body:
-            adf["content"].append({
-                "type": "paragraph",
-                "content": [{"type": "text", "text": self.body}]
-            })
+            adf["content"].append(
+                {"type": "paragraph", "content": [{"type": "text", "text": self.body}]}
+            )
         if self.url:
-            adf["content"].append({
-                "type": "paragraph",
-                "content": [{
-                    "type": "text", "text": self.url_text,
-                    "marks": [{"type": "link", "attrs": {"href": self.url}}]
-                }]
-            })
+            adf["content"].append(
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": self.url_text,
+                            "marks": [{"type": "link", "attrs": {"href": self.url}}],
+                        }
+                    ],
+                }
+            )
         return adf
 
     def to_slack_payload(self):
@@ -249,17 +263,17 @@ class Message(Event):
         """
         blocks = []
         if self.title:
-            blocks.append({
-                "type": "header",
-                "text": {
-                    "type": "plain_text",
-                    "text": ":sparkles: " + self.title,
-                    "emoji": True
+            blocks.append(
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": ":sparkles: " + self.title,
+                        "emoji": True,
+                    },
                 }
-            })
-            blocks.append({
-                "type": "divider"
-            })
+            )
+            blocks.append({"type": "divider"})
         if self.body:
             body = {
                 "type": "section",
@@ -269,21 +283,17 @@ class Message(Event):
                 body["accessory"] = {
                     "type": "image",
                     "image_url": self.image,
-                    "alt_text": self.image_altext
+                    "alt_text": self.image_altext,
                 }
             blocks.append(body)
         if self.url:
-            blocks.append({
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"*<{self.url}|{self.url_text}>*"}
-            })
-        return {
-            "attachments": [{
-                "blocks": blocks
-            }]
-        }
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": f"*<{self.url}|{self.url_text}>*"},
+                }
+            )
+        return {"attachments": [{"blocks": blocks}]}
 
     def to_jira_payload(self, profile):
         """
@@ -299,7 +309,7 @@ class Message(Event):
                 "reporter": {"id": profile.reporter_id},
                 "priority": {"id": "3"},
                 "labels": [profile.label],
-                "description": self.to_ADF()
+                "description": self.to_ADF(),
             }
         }
 
@@ -320,7 +330,8 @@ class Message(Event):
 
         # Record the MIME types of both parts - text/plain and text/html.
         part1 = MIMEText(self.body, 'plain')
-        part2 = MIMEText(f"""
+        part2 = MIMEText(
+            f"""
         <!DOCTYPE html>
         <html>
             <head>
@@ -329,7 +340,9 @@ class Message(Event):
             <body>
                 <p>{self.body}</p>
             </body>
-        </html>""", 'html')
+        </html>""",
+            'html',
+        )
 
         # Attach parts into message container.
         # According to RFC 2046, the last part of a multipart message, in this case

--- a/biothings/web/analytics/notifiers.py
+++ b/biothings/web/analytics/notifiers.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from biothings.web.analytics.channels import SlackChannel, GAChannel
+from biothings.web.analytics.channels import SlackChannel, GAChannel, GA4Channel
 from tornado.httpclient import AsyncHTTPClient
 from tornado.web import RequestHandler
 
@@ -18,6 +18,12 @@ class Notifier:
             self.channels.append(GAChannel(
                 getattr(settings, 'GA_ACCOUNT'),
                 getattr(settings, 'GA_UID_GENERATOR_VERSION', 1)
+            ))
+        if getattr(settings, 'GA4_MEASUREMENT_ID', None):
+            self.channels.append(GA4Channel(
+                measurement_id=getattr(settings, 'GA4_MEASUREMENT_ID'),
+                api_secret=getattr(settings, 'GA4_API_SECRET'),
+                uid_version=getattr(settings, 'GA4_UID_GENERATOR_VERSION', 1)
             ))
 
     def broadcast(self, event):

--- a/biothings/web/analytics/notifiers.py
+++ b/biothings/web/analytics/notifiers.py
@@ -1,35 +1,38 @@
 from collections import defaultdict
 
-from biothings.web.analytics.channels import SlackChannel, GAChannel, GA4Channel
 from tornado.httpclient import AsyncHTTPClient
 from tornado.web import RequestHandler
 
+from biothings.web.analytics.channels import GA4Channel, GAChannel, SlackChannel
+
 
 class Notifier:
-
     def __init__(self, settings):
         self.channels = []
 
         if hasattr(settings, 'SLACK_WEBHOOKS'):
-            self.channels.append(SlackChannel(
-                getattr(settings, 'SLACK_WEBHOOKS')
-            ))
+            self.channels.append(SlackChannel(getattr(settings, 'SLACK_WEBHOOKS')))  # noqa B009
         if getattr(settings, 'GA_ACCOUNT', None):
-            self.channels.append(GAChannel(
-                getattr(settings, 'GA_ACCOUNT'),
-                getattr(settings, 'GA_UID_GENERATOR_VERSION', 1)
-            ))
+            self.channels.append(
+                GAChannel(
+                    getattr(settings, 'GA_ACCOUNT'),  # noqa B009
+                    getattr(settings, 'GA_UID_GENERATOR_VERSION', 1),
+                )
+            )
         if getattr(settings, 'GA4_MEASUREMENT_ID', None):
-            self.channels.append(GA4Channel(
-                measurement_id=getattr(settings, 'GA4_MEASUREMENT_ID'),
-                api_secret=getattr(settings, 'GA4_API_SECRET'),
-                uid_version=getattr(settings, 'GA4_UID_GENERATOR_VERSION', 1)
-            ))
+            self.channels.append(
+                GA4Channel(
+                    measurement_id=getattr(settings, 'GA4_MEASUREMENT_ID'),  # noqa B009
+                    api_secret=getattr(settings, 'GA4_API_SECRET'),  # noqa B009
+                    uid_version=getattr(settings, 'GA4_UID_GENERATOR_VERSION', 2),
+                )
+            )
 
     def broadcast(self, event):
         for channel in self.channels:
             if channel.handles(event):
                 yield from channel.send(event)
+
 
 # Web Framework Support
 # ----------------------------

--- a/config.py.example
+++ b/config.py.example
@@ -51,7 +51,7 @@ HUB_DB_BACKEND = {
 
 # Hub environment (like, prod, dev, ...)
 # Used to generate remote metadata file, like "latest.json", "versions.json"
-# If non-empty, this constant will be used to generate those url, as a prefix 
+# If non-empty, this constant will be used to generate those url, as a prefix
 # with "-" between. So, if "dev", we'll have "dev-latest.json", etc...
 # "" means production
 HUB_ENV = ""
@@ -60,7 +60,7 @@ HUB_ENV = ""
 # List of package paths for active datasources
 ACTIVE_DATASOURCES = []
 
-#* 3. Folders *# 
+#* 3. Folders *#
 # Path to a folder to store all downloaded files, logs, caches, etc...
 DATA_ARCHIVE_ROOT = "/tmp/testhub/datasources"
 
@@ -88,3 +88,21 @@ logger = setup_default_log("hub", LOG_FOLDER)
 GA4_MEASUREMENT_ID = 'G-XXXXXXXXXX'
 GA4_API_SECRET = 'XtXXXXXXXXXXVw'
 GA4_UID_GENERATOR_VERSION = 1
+
+
+# *****************************************************************************
+# Analytics Settings
+# *****************************************************************************
+
+# Google Analytics Account ID
+
+GA_ACCOUNT = 'UA-123123-1'
+
+# Google Measurement ID
+GA4_MEASUREMENT_ID = 'G-KXzzzzLBN'
+
+# Google API Secret
+GA4_API_SECRET = '62rjfgrzzzzOcf7qNG5JA'
+
+# Google uid gerenator version
+GA4_UID_GENERATOR_VERSION = 2

--- a/config.py.example
+++ b/config.py.example
@@ -84,3 +84,7 @@ LOG_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, "logs")
 
 # Provide a default hub logger instance (use setup_default_log(name,log_folder)
 logger = setup_default_log("hub", LOG_FOLDER)
+
+GA4_MEASUREMENT_ID = 'G-XXXXXXXXXX'
+GA4_API_SECRET = 'XtXXXXXXXXXXVw'
+GA4_UID_GENERATOR_VERSION = 1

--- a/tests/web/analytics/test_channels.py
+++ b/tests/web/analytics/test_channels.py
@@ -1,5 +1,7 @@
 from biothings.web.analytics.channels import *
+from biothings.web.analytics.events import GAEvent
 from tornado.httpclient import HTTPClient
+
 
 def test_1():
     event = GAEvent({
@@ -23,5 +25,28 @@ def test_1():
         print(client.fetch(request))
 
 
+def test_2():
+    event = GAEvent({
+        "__request__": {
+            "user_agent": "Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1",
+            "referer": None,
+            "user_ip": "127.0.0.1",
+            "host": "example.org",
+            "path": "/"
+        },
+        "category": "test",
+        "action": "play",
+        "label": "sample.mp4",
+        "value": 60
+    })
+    channel = GA4Channel("GA4_MEASUREMENT_ID", "GA4_API_SECRET", 1)
+    assert channel.handles(event)
+
+    client = HTTPClient()
+    for request in channel.send(event):
+        print(client.fetch(request))
+
+
 if __name__ == '__main__':
     test_1()
+    test_2()

--- a/tests/web/analytics/test_events.py
+++ b/tests/web/analytics/test_events.py
@@ -4,6 +4,7 @@ from pprint import pprint as print
 # validator
 # https://ga-dev-tools.web.app/hit-builder/
 
+
 def test_pageview_1():
     event = Event(dict(__request__={
         "user_agent": "Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1",
@@ -15,6 +16,7 @@ def test_pageview_1():
     print(event.to_GA_payload("UA-000000-2"))
     print(event.to_GA_payload("UA-000000-2", 2))
 
+
 def test_pageview_2():
     event = Event(dict(__request__={
         "user_agent": None,
@@ -25,6 +27,7 @@ def test_pageview_2():
     }))
     print(event.to_GA_payload("UA-000000-2"))
     print(event.to_GA_payload("UA-000000-2", 2))
+
 
 def test_event_1():
     event = GAEvent({
@@ -43,6 +46,7 @@ def test_event_1():
     print(event.to_GA_payload("UA-000000-2"))
     print(event.to_GA_payload("UA-000000-2", 2))
 
+
 def test_event_2():
     event = GAEvent({
         "__request__": {
@@ -55,6 +59,62 @@ def test_event_2():
     })
     print(event.to_GA_payload("UA-000000-2"))
     print(event.to_GA_payload("UA-000000-2", 2))
+
+
+def test_pageview_ga4_1():
+    event = Event(dict(__request__={
+        "user_agent": "Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1",
+        "referer": "https://example.com/",
+        "user_ip": "127.0.0.1",
+        "host": "example.org",
+        "path": "/"
+    }))
+    print(event.to_GA4_payload("GA4_MEASUREMENT_ID"))
+    print(event.to_GA4_payload("GA4_MEASUREMENT_ID", 2))
+
+
+def test_pageview_ga4_2():
+    event = Event(dict(__request__={
+        "user_agent": None,
+        "referer": None,
+        "user_ip": "127.0.0.1",
+        "host": "example.org",
+        "path": "/404.html"
+    }))
+    print(event.to_GA4_payload("GA4_MEASUREMENT_ID"))
+    print(event.to_GA4_payload("GA4_MEASUREMENT_ID", 2))
+
+
+def test_event_ga4_1():
+    event = GAEvent({
+        "__request__": {
+            "user_agent": "Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1",
+            "referer": "https://example.com/",
+            "user_ip": "127.0.0.1",
+            "host": "example.org",
+            "path": "/"
+        },
+        "category": "video",
+        "action": "play",
+        "label": "sample.mp4",
+        "value": 60
+    })
+    print(event.to_GA4_payload("GA4_MEASUREMENT_ID"))
+    print(event.to_GA4_payload("GA4_MEASUREMENT_ID", 2))
+
+
+def test_event_ga4_2():
+    event = GAEvent({
+        "__request__": {
+            "user_agent": "Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1",
+            "referer": "https://example.com/",
+            "user_ip": "127.0.0.1",
+            "host": "example.org",
+            "path": "/"
+        }
+    })
+    print(event.to_GA4_payload("GA4_MEASUREMENT_ID"))
+    print(event.to_GA4_payload("GA4_MEASUREMENT_ID", 2))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ref https://github.com/biothings/biothings.api/issues/221

This is the debug log when I make a request to the biothings.web app, with enable both UA and GA4 channel:
`GET /v1/taxamony/metadata/?test=yes`

```
[INFO tornado.access:2271] 200 GET /v1/taxamony/metadata/?test=yes (13.244.85.86) 15.54ms

POST: http://www.google-analytics.com/batch 
v=1&t=pageview&tid=UA-227436864-1&cid=2075965986&uip=13.244.85.86&dh=localhost%3A9999&dp=%2Fv1%2Ftaxamony%2Fmetadata%2F&dr=&ua=Datadog%2FSynthetics
v=1&t=event&tid=UA-227436864-1&cid=765769904&ec=v1_api&ea=metadata_get
v=1&t=event&tid=UA-227436864-1&cid=895504088&ec=parameter_tracking&ea=field_filter&el=all'

POST: https://www.google-analytics.com/mp/collect?measurement_id=G-KXzzzxLLBN&api_secret=62rjfgrsssssf7qNG5JA 
'{"client_id":"103d70d6-6a53-4e98-9124-526c07d59fbe","user_id":"351397069","events":[
{"name":"page_view","params":{"page_location":"localhost:9999/v1/taxamony/metadata/","page_title":"v1-taxamony-metadata","page_referrer":"","user_agent":"Datadog/Synthetics"}},
{"name":"metadata_get","params":{"event_category":"v1_api"}},
{"name":"field_filter","params":{"event_category":"parameter_tracking","event_label":"all"}}
]}'
```
You can see there are three events are sent on each channel:
- Page view, all event parameters are mapped following [this article](https://support.google.com/analytics/answer/9964640?hl=en&ref_topic=12154439,12153943,2986333,&visit_id=637956330378025334-3968971007&rd=1#pageviews&zippy=%2Cin-this-article)
- metadata_get, all event parameters are mapped following [this article](https://support.google.com/analytics/answer/11091026?hl=en&ref_topic=11091421#zippy=%2Cin-this-article)
- field_filter, all event parameters are mapped following [this article](https://support.google.com/analytics/answer/11091026?hl=en&ref_topic=11091421#zippy=%2Cin-this-article)

This is the UA and GA4 report of the Aug 10 2022:

<img width="1371" alt="Screen Shot 2022-08-13 at 01 38 04" src="https://user-images.githubusercontent.com/67749546/184422699-86ce99de-3273-4cc1-9bf6-59da927c4255.png">
<img width="1376" alt="Screen Shot 2022-08-13 at 01 38 37" src="https://user-images.githubusercontent.com/67749546/184422788-00416dc4-1370-4c09-a4d6-f399cc3db501.png">

Then I think those conditions are matched:
- Existing UA tracking is still working
- New GA4 tracking can be enabled via a config parameter
- Confirm GA4 tracking captures the same API usage as the local access logs
