### PR TITLE
Fix error when trying to get mongo's HOST, PORT from DB client

### DIFF
--- a/biothings/hub/databuild/backend.py
+++ b/biothings/hub/databuild/backend.py
@@ -318,7 +318,7 @@ def create_backend(db_col_names, name_only=False, follow_ref=False, **kwargs):
         col = db[db_col_names[1]]
         # normalize params (0:host, 1:port)
         db_col_names = [
-            "%s:%s" % (db.client.address[0], db.client.address[1]), db.name,
+            "%s:%s" % (db.client.HOST, db.client.PORT), db.name,
             col.name
         ]
     assert col is not None, "Could not create collection object from %s" % repr(


### PR DESCRIPTION
`TypeError: 'NoneType' object is not subscriptable`

This error occurred, when running `inspect` command. It happened because we tried to get MongoDB's HOST, PORT from `DB Client.address` property.
This property actually checks the current topology value for valid value.
If not, it return `None` instead.
The current invalid value is: `TOPOLOGY_TYPE.UNKNOWN`
The valid should be: 
```
TOPOLOGY_TYPE.ReplicaSetWithPrimary,
TOPOLOGY_TYPE.Single,
TOPOLOGY_TYPE.LoadBalanced,
TOPOLOGY_TYPE.Sharded
```

Due to it is the internal behaviour of Pymongo, and in other place in ourcode base, we get HOST, PORT value directly from DB Client, so I decided to do the same.