### PR TITLE
Fixed an error when using python 3.9, 3.10: thread.isAlive was replac…

### DIFF
--- a/biothings/utils/manager.py
+++ b/biothings/utils/manager.py
@@ -1068,7 +1068,7 @@ async def %s():
         res = {}
         for child in tchildren:
             res[child.name] = {
-                "is_alive": child.isAlive(),
+                "is_alive": child.is_alive(),
                 "is_daemon": child.isDaemon(),
             }
 


### PR DESCRIPTION
…ed by thread.is_alive

Ref: https://bugs.python.org/issue37804