### PR TITLE
Fix error cannot quit hub's shell by using CTRL+D

### DIFF
--- a/biothings/hub/__init__.py
+++ b/biothings/hub/__init__.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent.futures
 import copy
 import glob
+import json
 import logging
 import os
 import sys
@@ -9,15 +10,21 @@ import time
 import types
 from collections import OrderedDict
 from functools import partial
+from importlib import import_module
 from pprint import pformat
 from types import SimpleNamespace
 
 import aiocron
 import asyncssh
+
 from biothings.utils.common import get_random_string, get_timestamp
-from biothings.utils.configuration import *
+from biothings.utils.configuration import (ConfigurationError,
+                                           ConfigurationWrapper)
 from biothings.utils.document_generator import generate_command_documentations
+
 from . import default_config
+
+config = None  # a global variable. It should be set by calling the _config_for_app function
 
 
 def _config_for_app(config_mod=None):
@@ -187,7 +194,7 @@ class JobRenderer(object):
         else:
             return "%s.%s" % (m.__self__.__class__.__name__, m.__name__)
 
-    def render_lambda(self, l):
+    def render_lambda(self, l):  # noqa: E741
         return l.__name__
 
 
@@ -897,8 +904,9 @@ class HubServer(object):
         if self.ws_urls:
             return self.ws_urls
 
-        import biothings.hub.api.handlers.ws as ws
         import sockjs.tornado
+
+        import biothings.hub.api.handlers.ws as ws
         from biothings.utils.hub_db import ChangeWatcher
 
         # monitor change in database to report activity in webapp
@@ -1608,7 +1616,7 @@ class HubSSHServer(asyncssh.SSHServer):
     SHELL = None
 
     def session_requested(self):
-        return HubSSHServerSession(self.__class__.NAME, self.__class__.SHELL, self._conn)
+        return HubSSHServerSession(self.__class__.NAME, self.__class__.SHELL)
 
     def connection_made(self, connection):
         self._conn = connection
@@ -1642,11 +1650,10 @@ class HubSSHServer(asyncssh.SSHServer):
 
 
 class HubSSHServerSession(asyncssh.SSHServerSession):
-    def __init__(self, name, shell, connection):
+    def __init__(self, name, shell):
         self.name = name
         self.shell = shell
         self._input = ''
-        self._conn = connection
 
     def connection_made(self, chan):
         self._chan = chan
@@ -1701,6 +1708,10 @@ class HubSSHServerSession(asyncssh.SSHServerSession):
         self._chan.exit(0)
 
     def soft_eof_received(self):
+        # After upgrading asyncssh from 2.5.0 to 2.11.0 or higher,
+        # in order to handle the EOF signal when user trigger a CTRL+D,
+        # the asyncssh calls the soft_eof_received callback instead of eof_received.
+        # This method is simple added to support this change.
         return self.eof_received()
 
     def break_received(self, msec):

--- a/biothings/hub/__init__.py
+++ b/biothings/hub/__init__.py
@@ -1608,7 +1608,7 @@ class HubSSHServer(asyncssh.SSHServer):
     SHELL = None
 
     def session_requested(self):
-        return HubSSHServerSession(self.__class__.NAME, self.__class__.SHELL)
+        return HubSSHServerSession(self.__class__.NAME, self.__class__.SHELL, self._conn)
 
     def connection_made(self, connection):
         self._conn = connection
@@ -1642,10 +1642,11 @@ class HubSSHServer(asyncssh.SSHServer):
 
 
 class HubSSHServerSession(asyncssh.SSHServerSession):
-    def __init__(self, name, shell):
+    def __init__(self, name, shell, connection):
         self.name = name
         self.shell = shell
         self._input = ''
+        self._conn = connection
 
     def connection_made(self, chan):
         self._chan = chan
@@ -1698,6 +1699,9 @@ class HubSSHServerSession(asyncssh.SSHServerSession):
     def eof_received(self):
         self._chan.write('Have a good one...\n')
         self._chan.exit(0)
+
+    def soft_eof_received(self):
+        return self.eof_received()
 
     def break_received(self, msec):
         # simulate CR


### PR DESCRIPTION
Ref: https://github.com/biothings/biothings.api/issues/246

There is an error occurs when the user try to quit Hub's shell by trigger EOF signal. (in this case the user use Ctrl+D)
```
INFO:asyncssh:[conn=1, chan=0] Closing channel
DEBUG:asyncssh:[conn=1] Uncaught exception
Traceback (most recent call last):
  File "/home/app/.pyenv/versions/test-biothings/lib/python3.10/site-packages/asyncssh/connection.py", line 1267, in data_received
    while self._inpbuf and self._recv_handler():
  File "/home/app/.pyenv/versions/test-biothings/lib/python3.10/site-packages/asyncssh/connection.py", line 1514, in _recv_packet
    processed = handler.process_packet(pkttype, seq, packet)
  File "/home/app/.pyenv/versions/test-biothings/lib/python3.10/site-packages/asyncssh/packet.py", line 237, in process_packet
    self._packet_handlers[pkttype](self, pkttype, pktid, packet)
  File "/home/app/.pyenv/versions/test-biothings/lib/python3.10/site-packages/asyncssh/channel.py", line 580, in _process_data
    self._accept_data(data)
  File "/home/app/.pyenv/versions/test-biothings/lib/python3.10/site-packages/asyncssh/channel.py", line 413, in _accept_data
    self._deliver_data(data, datatype)
  File "/home/app/.pyenv/versions/test-biothings/lib/python3.10/site-packages/asyncssh/channel.py", line 377, in _deliver_data
    self._session.data_received(decoded_data, datatype)
  File "/home/app/.pyenv/versions/test-biothings/lib/python3.10/site-packages/asyncssh/editor.py", line 947, in data_received
    self._editor.process_input(data, datatype)
  File "/home/app/.pyenv/versions/test-biothings/lib/python3.10/site-packages/asyncssh/editor.py", line 707, in process_input
    self._chan.write(''.join(self._outbuf))
  File "/home/app/.pyenv/versions/test-biothings/lib/python3.10/site-packages/asyncssh/channel.py", line 906, in write
    raise BrokenPipeError('Channel not open for sending')
BrokenPipeError: Channel not open for sending
INFO:asyncssh:[conn=1, chan=0] Closing channel due to connection close
INFO:asyncssh:[conn=1, chan=0] Channel closed: Channel not open for sending
SSH connection error: Channel not open for sending
```

After a lot of effort, I still cannot fix this problem, even try to add wait for channel closed, connection close.
I think we can safely ignore it, because this error seems not cause any problem to our Hub.
Also, there is an asyncssh's dev 's comment about this problem, which noted that the error is a legitimate error.  https://github.com/ronf/asyncssh/issues/129#issuecomment-379130673

```
As noted above, some "Broken Pipe" errors will still be seen here if the server gets an SSH connection close while operations are still in progress in some cases, but that's a legitimate error returned by the stack when trying to write a response on a closed socket.
```