### PR TITLE
Fix warning raises when same MongoClient instance is used in different processes

### DIFF
--- a/biothings/utils/configuration.py
+++ b/biothings/utils/configuration.py
@@ -1,9 +1,8 @@
-
-
 import inspect
 import json
 from json.decoder import JSONDecodeError
 import re
+import os
 from collections import UserList, UserString, deque
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
@@ -89,6 +88,9 @@ class ConfigurationWrapper():
         or new variables will be added if not defined in default_conf.
         Only metadata come from default_config will be used.
         """
+
+        # Store current pid to use later for checking with the runtime's pid.
+        self._pid = os.getpid()
 
         self._module = conf  # python module, typically config.py
         # update self._module with default value for missing configrations
@@ -271,6 +273,14 @@ class ConfigurationWrapper():
 
         if not self._db:  # without db, only support module params.
             raise AttributeError("Transient parameter requires DB setup.")
+
+        # Our db instance is shared with child process when this process is folked, and that action it not fork-safe.
+        # So we must recreate db instance in the child process.
+        # Ref: https://pymongo.readthedocs.io/en/stable/faq.html#id3
+        if os.getpid() != self._pid:
+            self._pid = os.getpid()
+            self._db = None
+            self._db = self._get_db_function()
 
         doc = self._db.find_one({"_id": name})
         if not doc:


### PR DESCRIPTION
```
/opt/home/mygene/venv/lib/python3.10/site-packages/pymongo/topology.py:164: UserWarning: MongoClient opened before fork. Create MongoClient only after forking. See PyMongo's documentation for details: https://pymongo.readthedocs.io/en/stable/faq.html#is-pymongo-fork-safe
```
This warning raises because we cache a `MongoClient` instance in the `ConfigurationWrapper`, and that instance is passed to the child process when the parent is folked.
That action is not folk-safe, and then `PyMongo` raises a warning to let's us know.

In this PR, I fixed the warning by store the `pid` of the process which create `ConfigurationWrapper`, and when the `ConfigurationWrapper.get_value_from_db` is called, we check that `pid` with `runtime's pid` to determine that the current process is child or not. If it is a child process, we must remove the old `MongoClient` instance, and replace with a new one.

