### PR TITLE
Support: 'Fetch >1000 documents with a POST query' using with_total option

### DIFF
--- a/biothings/web/query/formatter.py
+++ b/biothings/web/query/formatter.py
@@ -174,7 +174,6 @@ class ESResultFormatter(ResultFormatter):
         """
         options = dotdict(options)
         if isinstance(response, list):
-            max_total = 0
             count_by_queries = {}
 
             responses_ = []
@@ -186,7 +185,6 @@ class ESResultFormatter(ResultFormatter):
             responses = [self.transform(res, **options) for res in response]
             for tpl, res in zip(templates, responses):
                 total = res.get('total', {}).get('value') or 0
-                max_total += total
                 if tpl['query'] not in count_by_queries:
                     count_by_queries[tpl['query']] = 0
                 count_by_queries[tpl['query']] += total
@@ -210,6 +208,7 @@ class ESResultFormatter(ResultFormatter):
                         responses_.append(hit_)
             response_ = list(filter(None, responses_))
             if options.with_total:
+                max_total = max(count_by_queries.values())
                 response_ = {
                     'max_total': max_total,
                     'hits': response_,

--- a/biothings/web/query/formatter.py
+++ b/biothings/web/query/formatter.py
@@ -176,7 +176,9 @@ class ESResultFormatter(ResultFormatter):
         if isinstance(response, list):
             max_total = 0
             count_query_exceed_max_size = 0
-            max_size = options.size or 1000
+            # If options.set isn't set, the default number of hits returned by the ES is 10.
+            # Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html#search-multi-search-api-request-body  # noqa: F501
+            max_size = options.size or 10
 
             responses_ = []
             options.pop('one', None)  # ignore

--- a/biothings/web/settings/default.py
+++ b/biothings/web/settings/default.py
@@ -128,6 +128,7 @@ QUERY_KWARGS = {
         'scopes': {'type': list, 'default': ['_id'], 'max': 1000},
         'from': {'type': int, 'max': 10000, 'alias': 'skip'},
         'sort': {'type': list, 'max': 10},
+        'with_total': {'type': bool},
     }
 }
 


### PR DESCRIPTION
Regarding to this issue: https://github.com/biothings/biothings.api/issues/233
this PR try to support fetching >1000 documents with a POST query, by adding a new `with_total` option.

- if `with_total` option is not included in the POST body, or set to False, the result of query api will be same as the original behaviour: return a list of documents which match the query terms.
- if `with_total` option is set to True, the result will be reformated as a dict, which looks like this:
```
{
    'max_total': 100,  // the total documents matchs the query terms.
    'msg': '12 query terms return > 1000 hits, using from=1000 to retrieve the remaining hits',  // only included if there is at least one query term return greater than <size> of hits. the <size> value will be the options.size or default to 1000 if not set.
    'hits': [...]  // the actual response's documents
}
```