### PR TITLE
Support post_filter for query webapi

### DIFF
--- a/biothings/web/settings/default.py
+++ b/biothings/web/settings/default.py
@@ -21,7 +21,7 @@ ES_INDICES = {
 ES_ARGS = {
     # https://elasticsearch-py.readthedocs.io/en/v7.12.1/connection.html
     'sniff': False,  # this is a shortcut to configure multiple values
-    'timeout': 60  # increase from default (10s) to support heavy query
+    'timeout': 60,  # increase from default (10s) to support heavy query
 }
 
 # *****************************************************************************
@@ -37,7 +37,7 @@ MONGO_ARGS = {
     # https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html \
     # #pymongo.mongo_client.MongoClient
     'connect': False,  # lazy connection to speed up initialization
-    'tz_aware': True  # to maintain consistency with the hub design
+    'tz_aware': True,  # to maintain consistency with the hub design
 }
 
 # *****************************************************************************
@@ -104,32 +104,34 @@ COMMON_KWARGS = {
     'dotfield': {'type': bool, 'default': False},
     '_sorted': {'type': bool, 'default': True},  # alaphabetically
     'always_list': {'type': list, 'max': 1000},
-    'allow_null': {'type': list, 'max': 1000}
+    'allow_null': {'type': list, 'max': 1000},
 }
 ANNOTATION_KWARGS = {
     '*': COMMON_KWARGS.copy(),
     'GET': {'id': {'type': str, 'path': 0, 'required': True}},
-    'POST': {'id': {'type': list, 'max': 1000, 'required': True, 'alias': 'ids'}}
+    'POST': {'id': {'type': list, 'max': 1000, 'required': True, 'alias': 'ids'}},
 }
 QUERY_KWARGS = {
     '*': COMMON_KWARGS.copy(),
     'GET': {
         'q': {'type': str, 'default': None},
         'aggs': {'type': list, 'max': 1000, 'alias': 'facets'},
+        'post_filter': {'type': str, 'default': None},
         'facet_size': {'type': int, 'default': 10, 'max': 1000},
         'from': {'type': int, 'max': 10000, 'alias': 'skip'},
         'userquery': {'type': str, 'alias': ['userfilter']},
         'sort': {'type': list, 'max': 10},
         'explain': {'type': bool},
         'fetch_all': {'type': bool},
-        'scroll_id': {'type': str}},
+        'scroll_id': {'type': str},
+    },
     'POST': {
         'q': {'type': list, 'required': True},
         'scopes': {'type': list, 'default': ['_id'], 'max': 1000},
         'from': {'type': int, 'max': 10000, 'alias': 'skip'},
         'sort': {'type': list, 'max': 10},
         'with_total': {'type': bool},
-    }
+    },
 }
 
 # LONG TERM GOAL: REMOVE THESE COMPATIBILITY SETTINGS

--- a/tests/web/handlers/test_query.py
+++ b/tests/web/handlers/test_query.py
@@ -600,6 +600,38 @@ class TestQueryKeywords(BiothingsWebAppTest):
         res = self.request('/v1/query?scroll_id=<invalid>', expect=400).json()
         assert res['success'] is False
 
+    def test_32_post_filters(self):
+        """
+        {
+            'facets': {
+                'type_of_gene': {
+                    '_type': 'terms',
+                    'missing': 0,
+                    'other': 0,
+                    'terms': [{'count': 79, 'term': 'protein-coding'}],
+                    'total': 79
+                }
+            },
+            'hits': [...],
+            'max_score': 0.4116186,
+            'took': 7,
+            'total': 1
+        }
+        """
+
+        res = self.request(
+            '/v1/query?q={q}&aggs={aggs}&post_filter={post_filter}'.format(
+                q='cyclin dependent kinase 2',
+                aggs='type_of_gene',
+                post_filter='taxid:216574',
+            )
+        ).json()
+
+        assert res['total'] == 1
+        term = res['facets']['type_of_gene']['terms'][0]
+        assert term['count'] == 79
+        assert term['term'] == 'protein-coding'
+
 
 class TestQueryString(BiothingsWebAppTest):
     def test_00_all(self):


### PR DESCRIPTION
Ref: https://github.com/biothings/biothings.api/issues/208

This PR tried to add support `post_filter` feature for the webapi's query, if provided, the search hits are filtered after the aggregations are calculated (https://www.elastic.co/guide/en/elasticsearch/reference/8.1/filter-search-results.html#post-filter)
That params should be provided in query_string format (https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html)

Example
```
GET /v1/query?q=cyclin dependent kinase 2&aggs=type_of_gene&post_filter=taxid:216574
```

- Response:
```
       {
            'facets': {
                'type_of_gene': {
                    '_type': 'terms',
                    'missing': 0,
                    'other': 0,
                    'terms': [{'count': 79, 'term': 'protein-coding'}],
                    'total': 79
                }
            },
            'hits': [...],
            'max_score': 0.4116186,
            'took': 7,
            'total': 1
        }
```