### PR TITLE
Support more fieds in manifest file

### DIFF
--- a/biothings/hub/dataplugin/assistant.py
+++ b/biothings/hub/dataplugin/assistant.py
@@ -502,6 +502,26 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                 manifest["uploaders"], manifest.get("__metadata__"), data_plugin_folder
             )
             self.__class__.uploader_manager.register_classes(assisted_uploader_classes)
+        if manifest.get("display_name"):
+            dp = get_data_plugin()
+            dp.update(
+                {"_id": self.plugin_name},
+                {
+                    "$set": {
+                        "plugin.display_name": manifest.get("display_name"),
+                    }
+                },
+            )
+        if manifest.get("biothings_type"):
+            dp = get_data_plugin()
+            dp.update(
+                {"_id": self.plugin_name},
+                {
+                    "$set": {
+                        "plugin.biothings_type": manifest.get("biothings_type"),
+                    }
+                },
+            )
 
 
 class AdvancedPluginLoader(BasePluginLoader):

--- a/biothings/hub/dataplugin/assistant.py
+++ b/biothings/hub/dataplugin/assistant.py
@@ -512,13 +512,13 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                     }
                 },
             )
-        if manifest.get("biothings_type"):
+        if manifest.get("biothing_type"):
             dp = get_data_plugin()
             dp.update(
                 {"_id": self.plugin_name},
                 {
                     "$set": {
-                        "plugin.biothings_type": manifest.get("biothings_type"),
+                        "plugin.biothing_type": manifest.get("biothing_type"),
                     }
                 },
             )

--- a/biothings/hub/dataplugin/dumper.py.tpl
+++ b/biothings/hub/dataplugin/dumper.py.tpl
@@ -12,7 +12,7 @@ import biothings.hub.dataload.dumper
 class $DUMPER_NAME($BASE_CLASSES):
 
     SRC_NAME = "$SRC_NAME"
-    SRC_ROOT_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, SRC_NAME)
+    SRC_ROOT_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, "$SRC_FOLDER_NAME")
     SCHEDULE = $SCHEDULE
     UNCOMPRESS = $UNCOMPRESS
     SRC_URLS = $SRC_URLS


### PR DESCRIPTION
- Ref: https://github.com/biothings/biothings.api/issues/254
- There are two commits here, one for fix typo and one for update code logic.
- We need update the web app for parsing and displaying those fields
- New manifest file looked likes:
```---
version: '0.3'
display_name: "Test test"
biothing_type: "biothing_type_test"
requires:
- pandas
- numpy
dumper:
  data_url:
  - https://s3.pgkb.org/data/annotations.zip
  - https://s3.pgkb.org/data/drugLabels.zip
  - https://s3.pgkb.org/data/occurrences.zip
  uncompress: true
uploaders:
- name: annotations
  parser: parser:load_annotations
  mapping: parser:custom_annotations_mapping
  ignore_duplicates: false
- name: druglabels
  parser: parser:load_druglabels
  ignore_duplicates: false
- name: occurrences
  parser: parser:load_occurrences
  ignore_duplicates: false
```
New fields will be fetched on the get source info API:
ex: GET /source/pharmgkb
response: 
```json
{
  "result": {
    "_id": "pharmgkb",
    "name": "pharmgkb",
    "download": {
      "status": "success"
      }
    },
    "upload": {
      "sources": {
      }
    },
    "mapping": {
    },
    "__metadata__": {
      "src_meta": {}
    },
    "inspect": {
    },
    "count": 6920,
    "data_plugin": {
      "plugin": {
        "url": "local://pharmgkb",
        "type": "local",
        "active": true,
        "loader": "manifest",
        "display_name": "Test test",
        "biothing_type": "biothing_type_test"
      },
      "download": {
      }
    }
  },
  "status": "ok"
}
```
