### PR TITLE
Minor fixe

### DIFF
--- a/biothings/hub/dataload/uploader.py
+++ b/biothings/hub/dataload/uploader.py
@@ -278,9 +278,14 @@ class BaseSourceUploader(object):
                 "Resource '%s' is already being uploaded (job: %s)" % (self.name, job)
             )
 
-    def load_data(self, data_folder):
-        """Parse data inside data_folder and return structure ready to be
-        inserted in database"""
+    def load_data(self, data_path):
+        """
+        Parse data from data_path and return structure ready to be inserted in database
+        In general, data_path is a folder path.
+        But in parallel mode (use parallelizer option), data_path is a file path
+        :param data_path: It can be a folder path or a file path
+        :return: structure ready to be inserted in database
+        """
         raise NotImplementedError("Implement in subclass")
 
     @classmethod

--- a/biothings/hub/dataload/uploader.py
+++ b/biothings/hub/dataload/uploader.py
@@ -82,10 +82,10 @@ def upload_worker(name, storage_class, loaddata_func, col_name, batch_size, batc
 
 
 class BaseSourceUploader(object):
-    '''
+    """
     Default datasource uploader. Database storage can be done
     in batch or line by line. Duplicated records aren't not allowed
-    '''
+    """
 
     # TODO: fix this delayed import
     from biothings import config
@@ -294,11 +294,11 @@ class BaseSourceUploader(object):
         return {}  # default to nothing...
 
     def make_temp_collection(self):
-        '''Create a temp collection for dataloading, e.g., entrez_geneinfo_INEMO.'''
+        """Create a temp collection for dataloading, e.g., entrez_geneinfo_INEMO."""
         if self.temp_collection_name:
             # already set
             return
-        self.temp_collection_name = self.collection_name + '_temp_' + get_random_string()
+        self.temp_collection_name = self.collection_name + "_temp_" + get_random_string()
         return self.temp_collection_name
 
     def clean_archived_collections(self):
@@ -315,14 +315,14 @@ class BaseSourceUploader(object):
             self.db[colname].drop()
 
     def switch_collection(self):
-        '''after a successful loading, rename temp_collection to regular collection name,
+        """after a successful loading, rename temp_collection to regular collection name,
         and renaming existing collection to a temp name for archiving purpose.
-        '''
+        """
         if self.temp_collection_name and self.db[self.temp_collection_name].count() > 0:
             if self.collection_name in self.db.collection_names():
                 # renaming existing collections
-                new_name = '_'.join(
-                    [self.collection_name, 'archive', get_timestamp(), get_random_string()]
+                new_name = "_".join(
+                    [self.collection_name, "archive", get_timestamp(), get_random_string()]
                 )
                 self.collection.rename(new_name, dropTarget=True)
             self.logger.info(
@@ -382,9 +382,9 @@ class BaseSourceUploader(object):
         # store mapping
         _map = self.__class__.get_mapping()
         if _map:
-            _doc['mapping'] = _map
+            _doc["mapping"] = _map
         # type of id being stored in these docs
-        if hasattr(self.__class__, '__metadata__'):
+        if hasattr(self.__class__, "__metadata__"):
             _doc.update(self.__class__.__metadata__)
         # try to find information about the uploader source code
         from biothings.hub.dataplugin.assistant import AssistedUploader
@@ -444,7 +444,9 @@ class BaseSourceUploader(object):
             # We should use the last_success from the last upload time as a default value for the current's last_success
             # If last_success from the last upload doesn't exist or is None, and last upload's status is success,
             # the last upload's started_at will be used.
-            last_upload_info = self.src_doc.get(subkey, {}).get("jobs", {}).setdefault(self.name, {})
+            last_upload_info = (
+                self.src_doc.get(subkey, {}).get("jobs", {}).setdefault(self.name, {})
+            )
             last_success = last_upload_info.get("last_success")
             last_status = last_upload_info.get("status")
             if not last_success and last_status == "success":
@@ -561,12 +563,12 @@ class BaseSourceUploader(object):
         """Sync with src_dump collection, collection information (src_doc)
         Return src_dump collection"""
         src_dump = get_src_dump()
-        self.src_doc = src_dump.find_one({'_id': self.main_source}) or {}
+        self.src_doc = src_dump.find_one({"_id": self.main_source}) or {}
         return src_dump
 
     def setup_log(self):
-        log_folder = os.path.join(config.LOG_FOLDER, 'dataload')
-        return get_logger('upload_%s' % self.fullname, log_folder=log_folder)
+        log_folder = os.path.join(config.LOG_FOLDER, "dataload")
+        return get_logger("upload_%s" % self.fullname, log_folder=log_folder)
 
     def __getattr__(self, attr):
         """This catches access to unpicabkle attributes. If unset,
@@ -587,20 +589,20 @@ class BaseSourceUploader(object):
 
 
 class NoBatchIgnoreDuplicatedSourceUploader(BaseSourceUploader):
-    '''Same as default uploader, but will store records and ignore if
+    """Same as default uploader, but will store records and ignore if
     any duplicated error occuring (use with caution...). Storage
     is done line by line (slow, not using a batch) but preserve order
     of data in input file.
-    '''
+    """
 
     storage_class = NoBatchIgnoreDuplicatedStorage
 
 
 class IgnoreDuplicatedSourceUploader(BaseSourceUploader):
-    '''Same as default uploader, but will store records and ignore if
+    """Same as default uploader, but will store records and ignore if
     any duplicated error occuring (use with caution...). Storage
     is done using batch and unordered bulk operations.
-    '''
+    """
 
     storage_class = IgnoreDuplicatedStorage
 
@@ -620,10 +622,10 @@ class DummySourceUploader(BaseSourceUploader):
     def prepare_src_dump(self):
         src_dump = get_src_dump()
         # just populate/initiate an src_dump record (b/c no dump before) if needed
-        self.src_doc = src_dump.find_one({'_id': self.main_source})
+        self.src_doc = src_dump.find_one({"_id": self.main_source})
         if not self.src_doc:
             src_dump.save({"_id": self.main_source})
-            self.src_doc = src_dump.find_one({'_id': self.main_source})
+            self.src_doc = src_dump.find_one({"_id": self.main_source})
         return src_dump
 
     def check_ready(self, force=False):
@@ -636,7 +638,7 @@ class DummySourceUploader(BaseSourceUploader):
         # dummy uploaders have no dumper associated b/c it's collection-only resource,
         # so fill minimum information so register_status() can set the proper release
         self.src_dump.update_one(
-            {'_id': self.main_source}, {"$set": {"download.release": release}}
+            {"_id": self.main_source}, {"$set": {"download.release": release}}
         )
         # sanity check, dummy uploader, yes, but make sure data is there
         assert self.collection.count() > 0, (
@@ -737,9 +739,9 @@ class NoDataSourceUploader(BaseSourceUploader):
 
 
 class UploaderManager(BaseSourceManager):
-    '''
+    """
     After registering datasources, manager will orchestrate source uploading.
-    '''
+    """
 
     SOURCE_CLASS = BaseSourceUploader
 
@@ -866,16 +868,15 @@ class UploaderManager(BaseSourceManager):
             klasses = self[src]
         except KeyError:
             raise ResourceNotFound(
-                "Can't find '%s' in registered sources (whether as main or sub-source)"
-                % src)
+                "Can't find '%s' in registered sources (whether as main or sub-source)" % src
+            )
 
         jobs = []
         try:
-            for i, klass in enumerate(klasses):
+            for _, klass in enumerate(klasses):
                 job = self.job_manager.submit(
-                    partial(self.create_and_update_master,
-                            klass,
-                            dry=dry))
+                    partial(self.create_and_update_master, klass, dry=dry)
+                )
                 jobs.append(job)
             tasks = asyncio.gather(*jobs)
 
@@ -891,8 +892,9 @@ class UploaderManager(BaseSourceManager):
             tasks.add_done_callback(done)
             return jobs
         except Exception as e:
-            logging.exception("Error while update src meta '%s': %s" % (src, e),
-                              extra={"notify": True})
+            logging.exception(
+                "Error while update src meta '%s': %s" % (src, e), extra={"notify": True}
+            )
             raise
 
     async def create_and_update_master(self, klass, dry=False):

--- a/biothings/hub/dataplugin/assistant.py
+++ b/biothings/hub/dataplugin/assistant.py
@@ -340,7 +340,7 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                 # default is not ID conversion at all
                 confdict["IMPORT_IDCONVERTER_FUNC"] = ""
                 confdict["IDCONVERTER_FUNC"] = None
-                confdict["CALL_PARSER_FUNC"] = "parser_func(data_folder, **parser_kwargs)"
+                confdict["CALL_PARSER_FUNC"] = "parser_func(data_path, **parser_kwargs)"
                 if uploader_section.get("keylookup"):
                     assert self.__class__.keylookup, (
                         "Plugin %s needs _id conversion " % self.plugin_name
@@ -363,7 +363,7 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                     )
                     confdict[
                         "CALL_PARSER_FUNC"
-                    ] = "self.__class__.idconverter(parser_func)(data_folder, **parser_kwargs)"
+                    ] = "self.__class__.idconverter(parser_func)(data_path, **parser_kwargs)"
                 if metadata:
                     confdict["__metadata__"] = metadata
                 else:

--- a/biothings/hub/dataplugin/assistant.py
+++ b/biothings/hub/dataplugin/assistant.py
@@ -10,7 +10,6 @@ import textwrap
 import urllib.parse
 from string import Template
 
-import orjson
 import requests
 import yaml
 from yapf.yapflib import yapf_api
@@ -42,9 +41,9 @@ class BasePluginLoader(object):
 
     def setup_log(self):
         """Setup and return a logger instance"""
-        log_folder = os.path.join(btconfig.LOG_FOLDER, 'dataload')
+        log_folder = os.path.join(btconfig.LOG_FOLDER, "dataload")
         self.logger, self.logfile = get_logger(
-            'loader_%s' % self.plugin_name, log_folder=log_folder
+            "loader_%s" % self.plugin_name, log_folder=log_folder
         )
 
     def get_plugin_obj(self):
@@ -234,7 +233,7 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                 self.plugin_name
             ), "Incorrect plugin name '%s' (doesn't match regex '%s'" % (self.plugin_name, pnregex)
             dumper_name = self.plugin_name.capitalize() + "Dumper"
-            '%s'
+            "%s"
             try:
                 if hasattr(btconfig, "DUMPER_TEMPLATE"):
                     tpl_file = btconfig.DUMPER_TEMPLATE
@@ -280,7 +279,7 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                 "Invalid manifest, expecting 'data_url' key in 'dumper' section"
             )
 
-    def get_uploader_dynamic_class(self, uploader_section, metadata, sub_source_name=''):
+    def get_uploader_dynamic_class(self, uploader_section, metadata, sub_source_name=""):
         if uploader_section.get("parser"):
             uploader_name = self.plugin_name.capitalize() + sub_source_name + "Uploader"
             confdict = {
@@ -292,23 +291,23 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                 mod, func = uploader_section.get("parser").split(":")
                 confdict["PARSER_MOD"] = mod
                 confdict["PARSER_FUNC"] = func
-                if uploader_section.get('parser_kwargs'):
-                    parser_kwargs_serialized = repr(uploader_section['parser_kwargs'])
+                if uploader_section.get("parser_kwargs"):
+                    parser_kwargs_serialized = repr(uploader_section["parser_kwargs"])
 
                     confdict["PARSER_FACTORY_CODE"] = textwrap.dedent(
-                        f'''
+                        f"""
                         # Setup parser to parser factory
                         from {mod} import {func} as parser_func
 
                         parser_kwargs = {parser_kwargs_serialized}
-                    '''
+                    """
                     )
                 else:
                     # create empty parser_kwargs to pass to parser_func
                     parser_kwargs_serialized = repr({})
 
                     confdict["PARSER_FACTORY_CODE"] = textwrap.dedent(
-                        f'''
+                        f"""
                     # when code is exported, import becomes relative
                     try:
                         from {self.plugin_name}.{mod} import {func} as parser_func
@@ -316,7 +315,7 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                         from .{mod} import {func} as parser_func
 
                     parser_kwargs = {parser_kwargs_serialized}
-                    '''
+                    """
                     )
             except ValueError:
                 raise AssistantException(
@@ -454,7 +453,7 @@ class ManifestBasedPluginLoader(BasePluginLoader):
     def get_uploader_dynamic_classes(self, uploader_section, metadata, data_plugin_folder):
         uploader_classes = []
         for uploader_conf in uploader_section:
-            sub_source_name = uploader_conf.get('name', '')
+            sub_source_name = uploader_conf.get("name", "")
             uploader_class = self.get_uploader_dynamic_class(
                 uploader_conf, metadata, sub_source_name
             )
@@ -476,7 +475,7 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                 reqs = [reqs]
             for req in reqs:
                 self.logger.info("Install requirement '%s'" % req)
-                subprocess.check_call([sys.executable, '-m', 'pip', 'install', req])
+                subprocess.check_call([sys.executable, "-m", "pip", "install", req])
         if manifest.get("dumper"):
             assisted_dumper_class = self.get_dumper_dynamic_class(
                 manifest["dumper"], manifest.get("__metadata__")
@@ -572,7 +571,7 @@ class BaseAssistant(object):
 
     def setup_log(self):
         """Setup and return a logger instance"""
-        self.logger, self.logfile = get_logger('assistant_%s' % self.__class__.plugin_type)
+        self.logger, self.logfile = get_logger("assistant_%s" % self.__class__.plugin_type)
 
     def register_loader(self):
         dp = get_data_plugin()
@@ -756,7 +755,7 @@ class AssistantManager(BaseSourceManager):
 
     def setup_log(self):
         """Setup and return a logger instance"""
-        self.logger, self.logfile = get_logger('assistantmanager')
+        self.logger, self.logfile = get_logger("assistantmanager")
 
     def create_instance(self, klass, url):
         return klass(url)
@@ -949,11 +948,11 @@ class AssistantManager(BaseSourceManager):
             res["uploader"]["status"] = "warning"
             res["uploader"]["message"] = "No uploader found for plugin '%s'" % plugin_name
             return res
-        status = 'ok'
-        message = ''
+        status = "ok"
+        message = ""
         for uclass in uclasses:
             try:
-                uploader_name = uclass.__name__.split('_')[1].capitalize() + "Uploader"
+                uploader_name = uclass.__name__.split("_")[1].capitalize() + "Uploader"
                 self.logger.debug("Exporting uploader %s" % uploader_name)
                 # assert len(uclass) == 1, "More than one uploader found: %s" % uclass
                 assert hasattr(uclass, "python_code"), "No generated code found"

--- a/biothings/hub/dataplugin/subuploader.py.tpl
+++ b/biothings/hub/dataplugin/subuploader.py.tpl
@@ -18,8 +18,8 @@ class $UPLOADER_NAME($BASE_CLASSES):
     idconverter = $IDCONVERTER_FUNC
     storage_class = $STORAGE_CLASS
 
-    def load_data(self,data_folder):
-        self.logger.info("Load data from directory: '%s'" % data_folder)
+    def load_data(self, data_path):
+        self.logger.info("Load data from directory or file: '%s'" % data_path)
         return $CALL_PARSER_FUNC
 
     $JOBS_FUNC

--- a/biothings/hub/dataplugin/uploader.py.tpl
+++ b/biothings/hub/dataplugin/uploader.py.tpl
@@ -17,8 +17,8 @@ class $UPLOADER_NAME($BASE_CLASSES):
     idconverter = $IDCONVERTER_FUNC
     storage_class = $STORAGE_CLASS
 
-    def load_data(self,data_folder):
-        self.logger.info("Load data from directory: '%s'" % data_folder)
+    def load_data(self, data_path):
+        self.logger.info("Load data from directory or file: '%s'" % data_path)
         return $CALL_PARSER_FUNC
 
     $JOBS_FUNC


### PR DESCRIPTION
When I work with [FIRE data plugin](https://github.com/remoteeng00/FIRE/tree/v2) - it uses parallelizer option for running uploader in parallel,  It shows the error:
```
biothings-demohub  |   File "/data/biothings_studio/plugins/FIRE/parser.py", line 11, in load_data
biothings-demohub  |     with open(file_name, "r+") as f:
biothings-demohub  | NotADirectoryError: [Errno 20] Not a directory: '/data/biothings_studio/datasources/FIRE/v2/FIRE_chrX_head100k.txt/FIRE_chrX_head100k.txt'
```
I see we can parallelizing per file when use `ParallelizedSourceUploader`, then the `load_data` function can be called and passed a file path as parameter. So I propose to make a bit update about this param name in this commit: https://github.com/newgene/biothings.api/commit/ab057e30fc4b1c6718e1f76f3cf137d98abad31d
Other commit is just fourmat fixes https://github.com/newgene/biothings.api/commit/a27b29794c4765ff68a8afb779b15e96fa1f595f