### PR TITLE
Add DockerContainerDumper class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ config.py
 !/tests/hub/hubdb/config.py
 .hubdb
 .hubdb.*
+*.biothings_hub*
 
 # other local files
 .notes/

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -2054,11 +2054,12 @@ class DockerContainerDumper(BaseDumper):
         remote_file = self.get_remote_file(remote_file_url)
 
         if self.DOCKER_RUN_CUSTOM_CMD:
-            exit_code, output = self.container.exec_run(["/usr/bin/sh", "-c",  self.DOCKER_RUN_CUSTOM_CMD])
+            exit_code, output = self.container.exec_run(["sh", "-c",  self.DOCKER_RUN_CUSTOM_CMD])
             self.logger.debug(output.decode())
             if exit_code != 0:
                 self.logger.error(f"Failed to download {remote_file}, non-zero exit code from custom cmd: {exit_code}")
                 self.logger.error(output)
+                raise DumperException(f"Can not run the custom command {self.DOCKER_RUN_CUSTOM_CMD}")
         try:
             bits, stat = self.container.get_archive(remote_file, encode_stream=True)
             if stat.get("size", 0) > 0:

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -1931,7 +1931,7 @@ class DockerContainerDumper(BaseDumper):
         file_dir = '/'.join(file_path.split("/")[:-1])
         self.logger.info(f"Start a docker container with the custom command {self.DOCKER_RUN_CUSTOM_CMD}")
         self.container = client.containers.run(
-            self.DOCKER_IMAGE, command=self.DOCKER_RUN_CUSTOM_CMD.strip('"'),
+            self.DOCKER_IMAGE, command=self.DOCKER_RUN_CUSTOM_CMD,
             detach=True, auto_remove=False,  # Don't auto remove this container, we need a stopped container when download file
             volumes={
                 self.volume.name: {'bind': file_dir, 'mode': 'rw'}

--- a/biothings/hub/dataplugin/assistant.py
+++ b/biothings/hub/dataplugin/assistant.py
@@ -118,8 +118,6 @@ class ManifestBasedPluginLoader(BasePluginLoader):
 
     def _dict_for_docker(self, data_url):
         d = self._dict_for_base(data_url)
-        d["TLS_CERT_PATH"] = None
-        d["TLS_KEY_PATH"] = None
         return d
 
     def can_load_plugin(self):
@@ -208,15 +206,6 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                 scheme = "docker"
             klass = dumper_section.get("class")
             confdict = getattr(self, "_dict_for_%s" % scheme)(durls)
-            if dumper_section.get("tls_cert_path"):
-                # tls_cert_path = os.path.join(df, dumper_section.get("tls_cert_path"))
-                # assert os.path.isfile(tls_cert_path), "Cert file does not exist!"
-                confdict["TLS_CERT_PATH"] = dumper_section.get("tls_cert_path")
-            if dumper_section.get("tls_key_path"):
-                # tls_key_path = os.path.join(df, dumper_section.get("tls_key_path"))
-                # assert os.path.isfile(tls_key_path), "Cert file does not exist!"
-                confdict["TLS_KEY_PATH"] = dumper_section.get("tls_key_path")
-            dumper_class = None
             if klass:
                 dumper_class = get_class_from_classpath(klass)
                 confdict["BASE_CLASSES"] = klass

--- a/biothings/hub/dataplugin/docker_dumper.py.tpl
+++ b/biothings/hub/dataplugin/docker_dumper.py.tpl
@@ -18,8 +18,6 @@ class $DUMPER_NAME($BASE_CLASSES):
     SRC_ROOT_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, SRC_NAME)
     SCHEDULE = $SCHEDULE
     UNCOMPRESS = $UNCOMPRESS
-    TLS_CERT_PATH = "$TLS_CERT_PATH"
-    TLS_KEY_PATH = "$TLS_KEY_PATH"
     SRC_URLS = $SRC_URLS
     __metadata__ = {"src_meta" : $__metadata__}
 

--- a/biothings/hub/dataplugin/docker_dumper.py.tpl
+++ b/biothings/hub/dataplugin/docker_dumper.py.tpl
@@ -1,0 +1,31 @@
+import os
+from urllib3.exceptions import InsecureRequestWarning
+from urllib3 import disable_warnings
+import biothings, config
+biothings.config_for_app(config)
+from config import DATA_ARCHIVE_ROOT
+
+from biothings.utils.common import uncompressall
+
+# Disable InsecureRequestWarning: Unverified HTTPS request is being made to host
+disable_warnings(InsecureRequestWarning)
+
+import biothings.hub.dataload.dumper
+
+class $DUMPER_NAME($BASE_CLASSES):
+
+    SRC_NAME = "$SRC_NAME"
+    SRC_ROOT_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, SRC_NAME)
+    SCHEDULE = $SCHEDULE
+    UNCOMPRESS = $UNCOMPRESS
+    TLS_CERT_PATH = "$TLS_CERT_PATH"
+    TLS_KEY_PATH = "$TLS_KEY_PATH"
+    SRC_URLS = $SRC_URLS
+    __metadata__ = {"src_meta" : $__metadata__}
+
+    def post_dump(self, *args, **kwargs):
+        if self.__class__.UNCOMPRESS:
+            self.logger.info("Uncompress all archive files in '%s'" % self.new_data_folder)
+            uncompressall(self.new_data_folder)
+
+    $SET_RELEASE_FUNC

--- a/biothings/hub/dataplugin/templates/manifest.yaml.tpl
+++ b/biothings/hub/dataplugin/templates/manifest.yaml.tpl
@@ -11,10 +11,11 @@ requires:  # Optional. Listing all extra packages if need
 #  - pandas
 #  - numpy
 dumper:
-  data_url:  # A string, or a list of strings, containins URLs. Currently supported protocols are: http, https, and ftp. http/https must not be mixed with ftp (only one protocol supported)
+  data_url:  # A string, or a list of strings, contains URLs. Currently supported protocols are: http, https, ftp, docker. http/https must not be mixed with ftp (only one protocol supported)
 #    - https://s3.pgkb.org/data/annotations.zip
 #    - https://s3.pgkb.org/data/drugLabels.zip
 #    - https://s3.pgkb.org/data/occurrences.zip
+# If you wan to use DockerContainerDumper class, please read its docstring
   uncompress: true  # true|false. tells the studio to try to uncompress downloaded data. Currently supports zip, gz, bz2 and xz format.
   schedule: '* * * * * */10'  # Optional. Will trigger the scheduling of the dumper, so it automatically checks for new data on a regular basis.
   # Format is the same as crontabs, with the addition of an Optionall sixth parameter for scheduling by the seconds.

--- a/biothings/hub/default_config.py
+++ b/biothings/hub/default_config.py
@@ -152,6 +152,9 @@ DOCKER_CONFIG = {
         "tls_cert_path": None,
         "tls_key_path": None,
         "client_url": ""
+    },
+    "localhost": {
+        "client_url": "unix://var/run/docker.sock"
     }
 }
 

--- a/biothings/hub/default_config.py
+++ b/biothings/hub/default_config.py
@@ -142,15 +142,17 @@ AUTO_ARCHIVE_CONFIG = {
 """
 
 # Docker connection configuration
-# docker_client_url should has the following formats:
-# ssh://remote_ip:port
+# client_url should match the following formats:
+# ssh://ubuntu@remote_ip:port
 # unix://var/run/docker.sock
 # http://remote_ip:port
 # https://remote_ip:port
 DOCKER_CONFIG = {
-    "tls_cert_path": None,
-    "tls_key_path": None,
-    "docker_client_url": ""
+    "docker1": {
+        "tls_cert_path": None,
+        "tls_key_path": None,
+        "client_url": ""
+    }
 }
 
 #* 3. Folders *#

--- a/biothings/hub/default_config.py
+++ b/biothings/hub/default_config.py
@@ -141,6 +141,18 @@ AUTO_ARCHIVE_CONFIG = {
 }
 """
 
+# Docker connection configuration
+# docker_client_url should has the following formats:
+# ssh://remote_ip:port
+# unix://var/run/docker.sock
+# http://remote_ip:port
+# https://remote_ip:port
+DOCKER_CONFIG = {
+    "tls_cert_path": None,
+    "tls_key_path": None,
+    "docker_client_url": ""
+}
+
 #* 3. Folders *#
 # Path to a folder to store all downloaded files, logs, caches, etc...
 DATA_ARCHIVE_ROOT = ConfigurationError("Define path to folder which will contain all downloaded data, cache files, etc...")

--- a/biothings/utils/common.py
+++ b/biothings/utils/common.py
@@ -744,6 +744,18 @@ def untargzall(folder, pattern="*.tar.gz"):
         tf.extractall(folder)
         logging.info("done untargz '%s'", tf.name)
 
+def untarall(folder, pattern="*.tar"):
+    '''
+    untar all ``*.tar`` files in "folder"
+    '''
+    import tarfile
+    for tg in glob.glob(os.path.join(folder, pattern)):
+        tf = tarfile.TarFile(tg)
+        sanitize_tarfile(tf, folder)
+        logging.info("untargz '%s'", tf.name)
+        tf.extractall(folder)
+        logging.info("done untar '%s'", tf.name)
+
 
 def gunzipall(folder, pattern="*.gz"):
     '''

--- a/biothings/utils/parsers.py
+++ b/biothings/utils/parsers.py
@@ -77,13 +77,13 @@ def json_array_parser(
 def docker_source_info_parser(url):
     """
     :param url: file url include docker connection string
-        format: docker://CONNECTION_NAME?image=DOCKER_IMAGE&tag=TAG&exec_command="python run.py"&path=/path/to/file
+        format: docker://CONNECTION_NAME?image=DOCKER_IMAGE&tag=TAG&dump_command="python run.py"&path=/path/to/file
         the CONNECTION_NAME must be defined in the biothings Hub config.
         example:
-        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&exec_command="python run.py"&path=/path/to/file
-        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&exec_command="python run.py"&path=/path/to/file
-        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&exec_command="python run.py"&path=/path/to/file
-        docker"//CONNECTION_NAME?image=docker_image&tag=docker_tag&exec_command="python run.py"&path=/path/to/file
+        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&dump_command="python run.py"&path=/path/to/file
+        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&dump_command="python run.py"&path=/path/to/file
+        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&dump_command="python run.py"&path=/path/to/file
+        docker"//CONNECTION_NAME?image=docker_image&tag=docker_tag&dump_command="python run.py"&path=/path/to/file
     :return:
 
     """
@@ -91,7 +91,7 @@ def docker_source_info_parser(url):
     query = dict(parse_qsl(parsed.query))
     image = query.get("image")
     image_tag = query.get("tag")
-    exec_command = query.get("exec_command")
+    dump_command = query.get("dump_command")
     keep_container = query.get("keep_container")
     container_name = query.get("container_name")
     get_version_cmd = query.get("get_version_cmd")
@@ -99,18 +99,17 @@ def docker_source_info_parser(url):
         keep_container = True
     else:
         keep_container = False
-    if exec_command:
-        exec_command = exec_command.strip('"')
+    if dump_command:
+        dump_command = dump_command.strip('"')
     if get_version_cmd:
         get_version_cmd = get_version_cmd.strip('"')
     if not image_tag:
         image_tag = "latest"
-    file_path = query["path"]
     docker_image = image and f"{image}:{image_tag}" or None
     return {
         "docker_image": docker_image,
-        "file_path": file_path,
-        "exec_command": exec_command,
+        "path": query.get("path"),
+        "dump_command": dump_command,
         "connection_name": parsed.netloc,
         "container_name": container_name,
         "keep_container": keep_container,

--- a/biothings/utils/parsers.py
+++ b/biothings/utils/parsers.py
@@ -77,13 +77,13 @@ def json_array_parser(
 def docker_source_info_parser(url):
     """
     :param url: file url include docker connection string
-        format: docker://CONNECTION_NAME?image=DOCKER_IMAGE&tag=TAG&custom_cmd="python run.py"&path=/path/to/file
+        format: docker://CONNECTION_NAME?image=DOCKER_IMAGE&tag=TAG&exec_command="python run.py"&path=/path/to/file
         the CONNECTION_NAME must be defined in the biothings Hub config.
         example:
-        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
-        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
-        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
-        docker"//CONNECTION_NAME?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&exec_command="python run.py"&path=/path/to/file
+        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&exec_command="python run.py"&path=/path/to/file
+        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&exec_command="python run.py"&path=/path/to/file
+        docker"//CONNECTION_NAME?image=docker_image&tag=docker_tag&exec_command="python run.py"&path=/path/to/file
     :return:
 
     """
@@ -91,7 +91,7 @@ def docker_source_info_parser(url):
     query = dict(parse_qsl(parsed.query))
     image = query.get("image")
     image_tag = query.get("tag")
-    custom_cmd = query.get("custom_cmd")
+    exec_command = query.get("exec_command")
     keep_container = query.get("keep_container")
     container_name = query.get("container_name")
     get_version_cmd = query.get("get_version_cmd")
@@ -99,8 +99,8 @@ def docker_source_info_parser(url):
         keep_container = True
     else:
         keep_container = False
-    if custom_cmd:
-        custom_cmd = custom_cmd.strip('"')
+    if exec_command:
+        exec_command = exec_command.strip('"')
     if get_version_cmd:
         get_version_cmd = get_version_cmd.strip('"')
     if not image_tag:
@@ -110,7 +110,7 @@ def docker_source_info_parser(url):
     return {
         "docker_image": docker_image,
         "file_path": file_path,
-        "custom_cmd": custom_cmd,
+        "exec_command": exec_command,
         "connection_name": parsed.netloc,
         "container_name": container_name,
         "keep_container": keep_container,

--- a/biothings/utils/parsers.py
+++ b/biothings/utils/parsers.py
@@ -92,6 +92,8 @@ def docker_source_info_parser(url):
     image = query["image"]
     image_tag = query.get("tag")
     custom_cmd = query.get("custom_cmd")
+    if custom_cmd:
+        custom_cmd = custom_cmd.strip('"')
     if not image_tag:
         image_tag = "latest"
     file_path = query["path"]

--- a/biothings/utils/parsers.py
+++ b/biothings/utils/parsers.py
@@ -77,12 +77,13 @@ def json_array_parser(
 def docker_source_info_parser(url):
     """
     :param url: file url include docker connection string
-        format: docker://?image=DOCKER_IMAGE&tag=TAG&custom_cmd="python run.py"&path=/path/to/file
+        format: docker://CONNECTION_NAME?image=DOCKER_IMAGE&tag=TAG&custom_cmd="python run.py"&path=/path/to/file
+        the CONNECTION_NAME must be defined in the biothings Hub config.
         example:
-        docker://?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
-        docker://?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
-        docker://?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
-        docker"//?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker://CONNECTION_NAME?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker"//CONNECTION_NAME?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
     :return:
 
     """
@@ -98,4 +99,5 @@ def docker_source_info_parser(url):
         "docker_image": f"{image}:{image_tag}",
         "file_path": file_path,
         "custom_cmd": custom_cmd,
+        "connection_name": parsed.netloc
     }

--- a/biothings/utils/parsers.py
+++ b/biothings/utils/parsers.py
@@ -95,7 +95,7 @@ def docker_source_info_parser(url):
     keep_container = query.get("keep_container")
     container_name = query.get("container_name")
     get_version_cmd = query.get("get_version_cmd")
-    if keep_container == "true":
+    if keep_container and keep_container.lower() in ["true", "yes", "1", "y"]:
         keep_container = True
     else:
         keep_container = False
@@ -114,5 +114,5 @@ def docker_source_info_parser(url):
         "connection_name": parsed.netloc,
         "container_name": container_name,
         "keep_container": keep_container,
-        "get_version_cmd": get_version_cmd
+        "get_version_cmd": get_version_cmd,
     }

--- a/biothings/utils/parsers.py
+++ b/biothings/utils/parsers.py
@@ -74,25 +74,19 @@ def json_array_parser(
     return json_array_parser
 
 
-def docker_connection_string_parser(url):
+def docker_source_info_parser(url):
     """
     :param url: file url include docker connection string
-        format: docker+DOCKER_CLIENT_URL?image=DOCKER_IMAGE&tag=TAG&custom_cmd="python run.py"&path=/path/to/file
+        format: docker://?image=DOCKER_IMAGE&tag=TAG&custom_cmd="python run.py"&path=/path/to/file
         example:
-        docker+ssh://remote_ip:1234?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
-        docker+unix://var/run/docker.sock?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
-        docker+http://remote_ip:1234?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
-        docker+https://remote_ip:1234?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker://?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker://?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker://?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker"//?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
     :return:
 
     """
     parsed = urlparse(url)
-    scheme = parsed.scheme
-    scheme = scheme.replace("docker+", "")
-    if scheme == "unix":
-        docker_client_url = url.rsplit("?", 1)[0].replace("docker+", "")
-    else:
-        docker_client_url = f"{scheme}://{parsed.netloc}"
     query = dict(parse_qsl(parsed.query))
     image = query["image"]
     image_tag = query.get("tag")
@@ -101,9 +95,7 @@ def docker_connection_string_parser(url):
         image_tag = "latest"
     file_path = query["path"]
     return {
-        "scheme": scheme,
         "docker_image": f"{image}:{image_tag}",
         "file_path": file_path,
-        "docker_client_url": docker_client_url,
         "custom_cmd": custom_cmd,
     }

--- a/biothings/utils/parsers.py
+++ b/biothings/utils/parsers.py
@@ -1,11 +1,13 @@
 import pathlib
 from typing import Callable, Generator, Iterable, Optional
+from urllib.parse import parse_qsl, urlparse
 
 import orjson
 
 
-def ndjson_parser(patterns: Optional[Iterable[str]] = None,) \
-        -> Callable[[str], Generator[dict, None, None]]:
+def ndjson_parser(
+    patterns: Optional[Iterable[str]] = None,
+) -> Callable[[str], Generator[dict, None, None]]:
     """
     Create NDJSON Parser given filename patterns
 
@@ -20,14 +22,15 @@ def ndjson_parser(patterns: Optional[Iterable[str]] = None,) \
             NDJSON files that matches the filename patterns
     """
     if patterns is None:
-        raise TypeError("Must provide keyword argument patterns to"
-                        "match files for NDJSON Parser")
+        raise TypeError(
+            "Must provide keyword argument patterns to" "match files for NDJSON Parser"
+        )
 
     def ndjson_parser_func(data_folder):
         work_dir = pathlib.Path(data_folder)
         for pattern in patterns:
             for filename in work_dir.glob(pattern):
-                with open(filename, 'rb') as f:
+                with open(filename, "rb") as f:
                     for line in f:
                         doc = orjson.loads(line)
                         yield doc
@@ -35,36 +38,72 @@ def ndjson_parser(patterns: Optional[Iterable[str]] = None,) \
     return ndjson_parser_func
 
 
-def json_array_parser(patterns: Optional[Iterable[str]] = None) \
-        -> Callable[[str], Generator[dict, None, None]]:
+def json_array_parser(
+    patterns: Optional[Iterable[str]] = None,
+) -> Callable[[str], Generator[dict, None, None]]:
     """
-       Create JSON Array Parser given filename patterns
+    Create JSON Array Parser given filename patterns
 
-       For use with manifest.json based plugins. The data comes in a JSON that is
-       an JSON array, containing multiple documents.
+    For use with manifest.json based plugins. The data comes in a JSON that is
+    an JSON array, containing multiple documents.
 
-       Args:
-           patterns: glob-compatible patterns for filenames, like *.json, data*.json
+    Args:
+        patterns: glob-compatible patterns for filenames, like *.json, data*.json
 
-       Returns:
-           parser_func
+    Returns:
+        parser_func
     """
     if patterns is None:
-        raise TypeError("Must provide keyword argument patterns to"
-                        "match files for JSON Array Parser")
+        raise TypeError(
+            "Must provide keyword argument patterns to" "match files for JSON Array Parser"
+        )
 
     def json_array_parser(data_folder):
         work_dir = pathlib.Path(data_folder)
         for pattern in patterns:
             for filename in work_dir.glob(pattern):
-                with open(filename, 'r') as f:
+                with open(filename, "r") as f:
                     data = orjson.loads(f.read())
                     try:
                         iterator = iter(data)
                     except TypeError:
-                        raise RuntimeError(f"{filename} does not contain a valid"
-                                           "JSON Array")
+                        raise RuntimeError(f"{filename} does not contain a valid" "JSON Array")
                     for doc in iterator:
                         yield doc
 
     return json_array_parser
+
+
+def docker_connection_string_parser(url):
+    """
+    :param url: file url include docker connection string
+        format: docker+DOCKER_CLIENT_URL?image=DOCKER_IMAGE&tag=TAG&custom_cmd="python run.py"&path=/path/to/file
+        example:
+        docker+ssh://remote_ip:1234?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker+unix://var/run/docker.sock?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker+http://remote_ip:1234?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+        docker+https://remote_ip:1234?image=docker_image&tag=docker_tag&custom_cmd="python run.py"&path=/path/to/file
+    :return:
+
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme
+    scheme = scheme.replace("docker+", "")
+    if scheme == "unix":
+        docker_client_url = url.rsplit("?", 1)[0].replace("docker+", "")
+    else:
+        docker_client_url = f"{scheme}://{parsed.netloc}"
+    query = dict(parse_qsl(parsed.query))
+    image = query["image"]
+    image_tag = query.get("tag")
+    custom_cmd = query.get("custom_cmd")
+    if not image_tag:
+        image_tag = "latest"
+    file_path = query["path"]
+    return {
+        "scheme": scheme,
+        "docker_image": f"{image}:{image_tag}",
+        "file_path": file_path,
+        "docker_client_url": docker_client_url,
+        "custom_cmd": custom_cmd,
+    }

--- a/biothings/utils/parsers.py
+++ b/biothings/utils/parsers.py
@@ -89,17 +89,30 @@ def docker_source_info_parser(url):
     """
     parsed = urlparse(url)
     query = dict(parse_qsl(parsed.query))
-    image = query["image"]
+    image = query.get("image")
     image_tag = query.get("tag")
     custom_cmd = query.get("custom_cmd")
+    keep_container = query.get("keep_container")
+    container_name = query.get("container_name")
+    get_version_cmd = query.get("get_version_cmd")
+    if keep_container == "true":
+        keep_container = True
+    else:
+        keep_container = False
     if custom_cmd:
         custom_cmd = custom_cmd.strip('"')
+    if get_version_cmd:
+        get_version_cmd = get_version_cmd.strip('"')
     if not image_tag:
         image_tag = "latest"
     file_path = query["path"]
+    docker_image = image and f"{image}:{image_tag}" or None
     return {
-        "docker_image": f"{image}:{image_tag}",
+        "docker_image": docker_image,
         "file_path": file_path,
         "custom_cmd": custom_cmd,
-        "connection_name": parsed.netloc
+        "connection_name": parsed.netloc,
+        "container_name": container_name,
+        "keep_container": keep_container,
+        "get_version_cmd": get_version_cmd
     }

--- a/config.py.example
+++ b/config.py.example
@@ -51,7 +51,7 @@ HUB_DB_BACKEND = {
 
 # Hub environment (like, prod, dev, ...)
 # Used to generate remote metadata file, like "latest.json", "versions.json"
-# If non-empty, this constant will be used to generate those url, as a prefix 
+# If non-empty, this constant will be used to generate those url, as a prefix
 # with "-" between. So, if "dev", we'll have "dev-latest.json", etc...
 # "" means production
 HUB_ENV = ""
@@ -60,7 +60,18 @@ HUB_ENV = ""
 # List of package paths for active datasources
 ACTIVE_DATASOURCES = []
 
-#* 3. Folders *# 
+# Docker connection configuration
+# docker_client_url should has the following formats:
+# ssh://remote_ip:port
+# unix://var/run/docker.sock
+# http://remote_ip:port
+# https://remote_ip:port
+DOCKER_CONFIG = {
+    "tls_cert_path": "/path/to/cert.pem",
+    "tls_key_path": "/path/to/key.pem",
+    "docker_client_url": "https://remote-ip:port"
+}
+#* 3. Folders *#
 # Path to a folder to store all downloaded files, logs, caches, etc...
 DATA_ARCHIVE_ROOT = "/tmp/testhub/datasources"
 

--- a/config.py.example
+++ b/config.py.example
@@ -61,15 +61,20 @@ HUB_ENV = ""
 ACTIVE_DATASOURCES = []
 
 # Docker connection configuration
-# docker_client_url should has the following formats:
-# ssh://remote_ip:port
+# client_url should match the following formats:
+# ssh://ubuntu@remote_ip:port
 # unix://var/run/docker.sock
 # http://remote_ip:port
 # https://remote_ip:port
 DOCKER_CONFIG = {
-    "tls_cert_path": "/path/to/cert.pem",
-    "tls_key_path": "/path/to/key.pem",
-    "docker_client_url": "https://remote-ip:port"
+    "connection_name_1": {
+        "tls_cert_path": "/path/to/cert.pem",
+        "tls_key_path": "/path/to/key.pem",
+        "client_url": "https://remote-docker-host:port"
+    },
+    "connection_name_2": {
+        "client_url": "ssh://user@remote-docker-host"
+    },
 }
 #* 3. Folders *#
 # Path to a folder to store all downloaded files, logs, caches, etc...

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,8 @@ hub_requires = [
     "rich",  # Lib for building CLI applications
     "biothings_client>=0.2.6",  # datatransform (api client),
     "cryptography==38.0.3", # for generate ssh keys, ssl cert.
+    "docker-py",  # Docker SDK for Python
+    "paramiko==2.12.0",  # Implementation of the SSHv2 protocol for Python
 ]
 
 # extra requirements to develop biothings

--- a/setup.py
+++ b/setup.py
@@ -79,9 +79,8 @@ hub_requires = [
     "biothings_client>=0.2.6",  # datatransform (api client)
     "typer[all]",  # Lib for building CLI applications
     "rich",  # Lib for building CLI applications
-    "biothings_client>=0.2.6",  # datatransform (api client),
     "cryptography==38.0.3", # for generate ssh keys, ssl cert.
-    "docker-py",  # Docker SDK for Python
+    "docker",  # Docker SDK for Python
     "paramiko==2.12.0",  # Implementation of the SSHv2 protocol for Python
 ]
 


### PR DESCRIPTION
ref: https://github.com/biothings/biothings.api/issues/266

Triggers a docker container (typically runs on a different server) to run and generate the output file, and then stop the container.The dumper class will then get the processed file(s) and send it to the Uploader as normally files to datasource folder

This dumper will act following steps:
     - Create a temporary docker volume on the remote server
     - Start a container and mount remote folder to the temporary volume
     - Wait for the container is stop - Supposing the remote file is ready for download
     - Download remote file via Docker API
     - Remove above container and volume after successfully download. If it failed to download, the container and volume will not be removed, then you can troubleshot issues by show the logs of this container on the remote server

These are supported connection type from the Hub server to the remote Docker host server:

- ssh: Prerequisite: the SSH Key-Based Authentication is configured
- unix: Local connection
- http: Use the insecure HTTP connection over TCP socket
- https:  Use secured HTTPS connection using TLS. Prerequisite:
  - The Docker API on the remote server MUST BE secured with TLS
  - A TLS key pair is generated on the Hub server and placed inside the same data plugin folder or the data source folder

The data_url should match the following format:
        **docker+DOCKER_CLIENT_URL?image=DOCKER_IMAGE&tag=TAG&path=/path/to/remote_file&custom_cmd="this is custom command"**
  - Supported params:
    - image: (Required) the Docker image name
    - path: (Required) path to the remote file inside the Docker container
    - tag: (Optional) the image tag
    - custom_cmd: (Optional) You don't need to fill this param if your docker entrypoint script already write output to the "/path/to/remote_file" file. Or you can override default docker entrypoint with this command with output to the /path/to/remote_file

Examples:
      - docker+unix:///var/run/docker.sock?image=IMAGE_NAME&tag=IMAGE_TAG&path=/path/to/remote_file(inside the container)&custom_cmd="run something with output is written to -O /path/to/remote_file (inside the container)"
      - docker+ssh://ubuntu@remote-server?image=IMAGE_NAME&tag=IMAGE_TAG&path=/path/to/remote_file(inside the container)&custom_cmd="run something with output is written to -O /path/to/remote_file (inside the container)"
      - docker+http://remote-server:2375?image=IMAGE_NAME&tag=IMAGE_TAG&path=/path/to/remote_file(inside the container)&custom_cmd="run something with output is written to -O /path/to/remote_file (inside the container)"
      - docker+http://remote-server:2375?image=IMAGE_NAME&tag=IMAGE_TAG&path=/path/to/remote_file(inside the container)&custom_cmd="run something with output is written to -O /path/to/remote_file (inside the container)"

A data plugin example, with TLS config following doc https://www.howtogeek.com/devops/how-to-secure-dockers-tcp-socket-with-tls/

```
---
version: '0.3'
requires:
- pandas
- numpy
dumper:
  tls_cert_path: client-certificate.pem
  tls_key_path: client-key.pem
  data_url:
  - docker+https://remote-server:2375?image=confluentinc/cp-kafka&tag=7.0.1&path=/tmp/annotations.zip&custom_cmd="/usr/bin/wget https://s3.pgkb.org/data/annotations.zip -O /tmp/annotations.zip"
  uncompress: true
uploader:
  parser: parser:load_annotations
  on_duplicates: ignore
```