### PR TITLE
Implement elasticsearch reindex feature

### DIFF
--- a/biothings/utils/es.py
+++ b/biothings/utils/es.py
@@ -957,26 +957,25 @@ class ESIndexer:
         settings = json.dumps({"index": {"number_of_replicas": number_of_replicas}})
         self.update_settings(settings)
 
-    def update_settings(self, settings, remove_meta_fields=False, close=False, **params):
+    def update_settings(self, settings, close=False, **params):
         """
         Parameters:
             - settings: should be valid ES index's settings.
-            - remove_meta_field: Some static fields like: "uuid", "provided_name", "creation_date", "version",
-                "number_of_shards", which ES doesn't allow update them.
             - close: In order to update static settings, the index must be closed first.
 
         Ref: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/index-modules.html#index-modules-settings
         """
-        if remove_meta_fields:
-            remove_fields = [
-                "uuid",
-                "provided_name",
-                "creation_date",
-                "version",
-                "number_of_shards",
-            ]
-            for field in remove_fields:
-                settings["index"].pop(field, None)
+        # Some static fields like: "uuid", "provided_name", "creation_date", "version",
+        #   "number_of_shards", which ES doesn't allow update them.
+        setting_fields_to_remove = [
+            "uuid",
+            "provided_name",
+            "creation_date",
+            "version",
+            "number_of_shards",
+        ]
+        for field in setting_fields_to_remove:
+            settings["index"].pop(field, None)
 
         if close:
             self.close()

--- a/biothings/utils/es.py
+++ b/biothings/utils/es.py
@@ -958,6 +958,15 @@ class ESIndexer:
         self.update_settings(settings)
 
     def update_settings(self, settings, remove_meta_fields=False, close=False, **params):
+        """
+        Parameters:
+            - settings: should be valid ES index's settings.
+            - remove_meta_field: Some static fields like: "uuid", "provided_name", "creation_date", "version",
+                "number_of_shards", which ES doesn't allow update them.
+            - close: In order to update static settings, the index must be closed first.
+
+        Ref: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/index-modules.html#index-modules-settings
+        """
         if remove_meta_fields:
             remove_fields = [
                 "uuid",

--- a/biothings/utils/es_reindex.py
+++ b/biothings/utils/es_reindex.py
@@ -1,0 +1,121 @@
+import logging
+from typing import Optional, Union
+
+from biothings.utils.es import ESIndexer
+
+logger = logging.getLogger(__name__)
+
+
+def reindex(
+    src_index: str,
+    src_index_extra_kwargs: Optional[dict] = None,
+    target_index: Optional[str] = None,
+    target_index_extra_kwargs: Optional[dict] = None,
+    settings: Optional[dict] = None,
+    mappings: Optional[dict] = None,
+    alias: Optional[Union[bool, str]] = None,
+    delete_src: Optional[bool] = False,
+) -> None:
+    """
+    This helper function helps to reindex an existing index by transferring both the settings, mappings and docs.
+    Mappings and settings from the src index will be used to create a new empty target index first.
+    Then Elasticsearch's reindex API will be used to transfer all docs to the new one.
+    Optionally, the alias can be switched over to the new index too.
+    This is useful when we need to migrate existing indices created from the srcer ES version to the current ES version.
+
+    Parameters:
+        src_index: name of the src index
+        src_index_extra_kwargs: a dict contains infor to construct ESIndexer for src index
+        target_index: name of the new index, use <src_index_name>_reindexed as default if None
+        target_index_extra_kwargs: a dict contains infor to construct ESIndexer for target index
+        settings: if provided as a dict, update the settings with the provided dictionary.
+                    Otherwise, keep the same from the src_index
+        mapping: if provided as a dict, update the settings with the provided mappings.
+                    Otherwise, keep the same from the src_index
+        alias: if True, switch the alias from src_index to target_index.
+                If src_index has no alias, apply the <src_index_name> as the alias;
+                if a string value, apply it as the alias instead
+        delete_src: If True, delete the src_index after everything is done
+
+    Returns:
+        None
+    """
+
+    logger.info("Starting reindex...")
+
+    # create indexer objects
+    logger.info("Create src index obj")
+    src_index_extra_kwargs = src_index_extra_kwargs or {}
+    src_index_obj = ESIndexer(index=src_index, **src_index_extra_kwargs)
+    assert src_index_obj.exists_index(), f"src index '{src_index}' is not exists."
+
+    logger.info("Create target index obj")
+    target_index = target_index or f"{src_index}_reindexed"
+    target_index_extra_kwargs = target_index_extra_kwargs or {}
+    if "number_of_shards" not in target_index_extra_kwargs:
+        target_index_extra_kwargs["number_of_shards"] = src_index_obj.number_of_shards
+    if "number_of_replicas" not in target_index_extra_kwargs:
+        target_index_extra_kwargs["number_of_replicas"] = src_index_obj.number_of_replicas
+    target_index_obj = ESIndexer(index=target_index, **target_index_extra_kwargs)
+    assert not target_index_obj.exists_index(), f"target index '{target_index}' is exists."
+
+    # clone settings, mappings from src index
+    logger.info("Clone src settings, and src_mapping, and update with supplied values")
+    src_settings = src_index_obj.get_settings(src_index_obj._index) or {}
+    src_mappings = src_index_obj.get_mapping() or {}
+
+    # update src settings, mappings with supplied values.
+    if settings:
+        src_settings.update(**settings)
+    if mappings:
+        src_mappings.update(**mappings)
+
+    # create target index with src settings, mappings
+    logger.info("Set target index's settings, mappings")
+    target_index_obj.create_index(mapping=src_mappings)
+    target_index_obj.update_settings(
+        src_settings[src_index_obj._index]["settings"],
+        remove_meta_fields=True,
+        close=True,
+    )
+
+    # Reindex from src index to target index
+    logger.info("Reindex from src index to target index")
+    is_remote = src_index_obj.es_host != target_index_obj.es_host
+    result = target_index_obj.reindex(src_index_obj, is_remote=is_remote)
+
+    logger.info(f"Reindex result: {result}")
+
+    # Refresh and flush target index
+    logger.info("Flush and refresh target index")
+    target_index_obj.flush_and_refresh()
+
+    # Check doc counts to make sure src_index, new index are equals
+    logger.info(
+        "Assert number of docs in target index must be equal to number of docs in src index"
+    )
+    count_src_docs = src_index_obj.count()
+    count_target_docs = target_index_obj.count()
+    if count_src_docs != count_target_docs:
+        raise Exception("Number of docs in target index not equal to number of docs in src index")
+
+    # Set target index's alias
+    if alias:
+        logger.info("Update target index's alias")
+        if isinstance(alias, str):
+            new_alias = alias
+        else:
+            try:
+                alias_data = src_index_obj.get_alias(index=src_index_obj._index)
+                new_alias = list(alias_data[src_index_obj._index]["aliases"].keys())[0]
+            except:  # noqa
+                # default to src_index name if src index is deleted or has no alias.
+                new_alias = src_index_obj._index
+        target_index_obj.update_alias(new_alias)
+
+    # Delete src index
+    if delete_src:
+        logger.info("Delete src alias")
+        src_index_obj.delete_index()
+
+    logger.info("Finished!")


### PR DESCRIPTION
Ref: https://github.com/biothings/biothings.api/issues/269

This helper function helps to reindex an existing index by transferring both the settings, mappings and docs.
    Mappings and settings from the src index will be used to create a new empty target index first.
    Then Elasticsearch's reindex API will be used to transfer all docs to the new one.
    Optionally, the alias can be switched over to the new index too.
    This is useful when we need to migrate existing indices created from the srcer ES version to the current ES version.

    Parameters:
        src_index: name of the src index
        src_index_extra_kwargs: a dict contains infor to construct ESIndexer for src index
        target_index: name of the new index, use <src_index_name>_reindexed as default if None
        target_index_extra_kwargs: a dict contains infor to construct ESIndexer for target index
        settings: if provided as a dict, update the settings with the provided dictionary.
                    Otherwise, keep the same from the src_index
        mapping: if provided as a dict, update the settings with the provided mappings.
                    Otherwise, keep the same from the src_index
        alias: if True, switch the alias from src_index to target_index.
                If src_index has no alias, apply the <src_index_name> as the alias;
                if a string value, apply it as the alias instead
        delete_src: If True, delete the src_index after everything is done

    Returns:
        None