### PR TITLE
fix autoreload feature

### DIFF
--- a/biothings/utils/hub.py
+++ b/biothings/utils/hub.py
@@ -817,6 +817,19 @@ def get_hub_reloader(*args, **kwargs):
         import tornado.autoreload  # noqa
 
         logging.info("Using Hub reloader based on tornado.autoreload")
+
+        def ensure_run_task(func):
+            def wrapper():
+                result = func()
+                if isinstance(result, asyncio.Future):
+                    asyncio.get_event_loop().run_until_complete(result)
+
+            return wrapper
+
+        if kwargs.get("reload_func"):
+            logging.info("Decorator reload_func to ensure it can be run")
+            kwargs["reload_func"] = ensure_run_task(kwargs["reload_func"])
+
         return TornadoAutoReloadHubReloader(*args, **kwargs)
     else:
         logging.info("USE_RELOADER not set (or False), won't monitor for changes")


### PR DESCRIPTION
There is a bug with Tornado `autoreload` module. It doesn't support Task-based reload hook.
Due to the Tornado only call our `reload_func`, and because it is actually an `asyncio.Task`, so that is not enough, our task is not execute yet.
The result is the Hub is restarted without killing old processes, and then cannot successfully starts.
```
INFO:hub:Starting 'BioThings Studio'
INFO:hub:Starting Hub API server on port 7081
INFO:root:Port 7081 is already used, sleep and retry (1/5)
Traceback (most recent call last):
  File "biothings.api/.notes/apps/start_hub.py", line 37, in <module>
    server.start()
  File "biothings.api/biothings/hub/__init__.py", line 553, in start
    start_api(api, config.HUB_API_PORT, settings=getattr(config, "TORNADO_SETTINGS", {}))
  File "biothings.api/biothings/hub/api/__init__.py", line 304, in start_api
    app_server.listen(port)
  File "/biothings/lib/python3.10/site-packages/tornado/tcpserver.py", line 183, in listen
    sockets = bind_sockets(
  File "/biothings/lib/python3.10/site-packages/tornado/netutil.py", line 162, in bind_sockets
    sock.bind(sockaddr)
OSError: [Errno 98] Address already in use
```

So I added a decorator to wrap the reload func, to ensure it must be run if it is an task instance.