### PR TITLE
Enhancement autohub: allow easily customize validation logic

### DIFF
--- a/biothings/hub/__init__.py
+++ b/biothings/hub/__init__.py
@@ -359,6 +359,7 @@ class HubServer(object):
         "version_urls": getattr(config, "VERSION_URLS", []),
         "indexer_factory": getattr(config, "AUTOHUB_INDEXER_FACTORY", None),
         "es_host": getattr(config, "AUTOHUB_ES_HOST", None),
+        "validator_class": getattr(config, "AUTOHUB_VALIDATOR_CLASS", None),
     }
 
     def __init__(
@@ -830,6 +831,7 @@ class HubServer(object):
         version_urls = self.autohub_config["version_urls"]
         indexer_factory = self.autohub_config["indexer_factory"]
         es_host = self.autohub_config["es_host"]
+        validator_class = self.autohub_config["validator_class"]
         factory = None
         if indexer_factory:
             assert (
@@ -842,7 +844,9 @@ class HubServer(object):
                 self.logger.error(
                     "Couldn't find indexer factory class from '%s': %s" % (indexer_factory, e)
                 )
-        self.autohub_feature = AutoHubFeature(autohub_managers, version_urls, factory)
+        self.autohub_feature = AutoHubFeature(
+            autohub_managers, version_urls, factory, validator_class=validator_class,
+        )
         try:
             self.autohub_feature.configure()
             self.autohub_feature.configure_auto_release(config)

--- a/biothings/hub/default_config.py
+++ b/biothings/hub/default_config.py
@@ -342,6 +342,10 @@ STANDALONE_VERSION = {"branch": "standalone_v2", "commit": None, "date": None}
 # A list of URLs to the versions.json files, which contain data release metadata
 VERSION_URLS = []
 
+# Use this configuration to customize validation logic of the auto hub feature.
+# the AutoHubValidator will be use as default. Any customize class must be extended from it.
+AUTOHUB_VALIDATOR_CLASS = None
+
 # Set to True to skip checking application/biothings version matching, before installing
 # a data release, in version settings like "app_version", "standalone_version", "biothings_version"
 SKIP_CHECK_COMPAT = True

--- a/biothings/hub/standalone/validators.py
+++ b/biothings/hub/standalone/validators.py
@@ -1,0 +1,22 @@
+class AutoHubValidateError(Exception):
+    reason = None
+
+    def __init__(self, reason, *args, **kwargs):
+        self.reason = reason
+        super().__init__(*args, **kwargs)
+
+
+class AutoHubValidator:
+    """
+    This class aims to provide an easy way to customize validation logic for installing a hub from a release.
+    """
+
+    def __init__(self, auto_hub_feature):
+        self.auto_hub_feature = auto_hub_feature
+
+    def validate(self, force=False, **kwargs):
+        """
+        Check if the release is valid to install.
+        If invalid, it should raise an AutoHubValidateError include any reason to stop the progress.
+        """
+        pass


### PR DESCRIPTION
This PR try to make the customize AutoHub's validation progress more easily, and straightforward.
The enduser who want to provide any custom validation logic, should subclass `biothings.hub.standalone.AutoHubValidator`, and set AUTOHUB_VALIDATOR_CLASS configuration to that class, or import as pass it to HubServer when instantinate hub server

Ref: https://github.com/biothings/biothings.api/issues/284